### PR TITLE
[ch100620] Handle types from core packages such as json.RawMessage

### DIFF
--- a/example/foo.go
+++ b/example/foo.go
@@ -1,9 +1,16 @@
 package main
 
+import (
+	"encoding/json"
+	"time"
+)
+
 type FooResponse struct {
 	ID        string          `json:"id"`
 	Bar       string          `json:"bar"`
 	Baz       string          `json:"baz"`
+	startDate time.Time       `json:"startDate"`
+	Msg       json.RawMessage `json:"msg"`
 	InnerFoos []InnerFoo      `json:"foo"`
 }
 

--- a/parser.go
+++ b/parser.go
@@ -34,11 +34,11 @@ type parser struct {
 	GoModFilePath string
 
 	GoModCachePath string
-	GoRootSrcPath string
+	GoRootSrcPath  string
 
 	OpenAPI OpenAPIObject
 
-	CorePkgs	  map[string]bool
+	CorePkgs      map[string]bool
 	KnownPkgs     []pkg
 	KnownNamePkg  map[string]*pkg
 	KnownPathPkg  map[string]*pkg
@@ -58,7 +58,7 @@ type pkg struct {
 
 func newParser(modulePath, mainFilePath, handlerPath string, debug bool) (*parser, error) {
 	p := &parser{
-		CorePkgs:	        	 map[string]bool{},
+		CorePkgs:                map[string]bool{},
 		KnownPkgs:               []pkg{},
 		KnownNamePkg:            map[string]*pkg{},
 		KnownPathPkg:            map[string]*pkg{},

--- a/parser_test.go
+++ b/parser_test.go
@@ -138,9 +138,9 @@ func TestExample(t *testing.T) {
                   "type":"string",
                   "format":"date-time"
                },
-			   "msg":{
-				  "type":"object"
-			   },
+               "msg":{
+                  "type":"object"
+               },
                "foo":{
                   "type":"array",
                   "items":{

--- a/parser_test.go
+++ b/parser_test.go
@@ -134,6 +134,13 @@ func TestExample(t *testing.T) {
                "baz":{
                   "type":"string"
                },
+               "startDate":{
+                  "type":"string",
+                  "format":"date-time"
+               },
+			   "msg":{
+				  "type":"object"
+			   },
                "foo":{
                   "type":"array",
                   "items":{


### PR DESCRIPTION
- walk the path of GOROOT to get the names of all core packages
- if a typedef is from a core package, handle it as being of type "object", and don't attempt to set a document ref