### PR TITLE
[ch100620] Use runtime.GOROOT rather than env variable which may not …

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -166,7 +167,7 @@ func newParser(modulePath, mainFilePath, handlerPath string, debug bool) (*parse
 	p.GoModCachePath = goModCachePath
 	p.debugf("go module cache path: %s", p.GoModCachePath)
 
-	goRoot := os.Getenv("GOROOT")
+	goRoot := runtime.GOROOT()
 	if goRoot == "" {
 		return nil, fmt.Errorf("cannot get GOROOT")
 	}


### PR DESCRIPTION
…be set

GOROOT env variable isn't always set (specifically, isn't set on circleci). Use runtime.GOROOT() instead