### PR TITLE
Raymond/ch103651/goas support reference to interfaces

### DIFF
--- a/example/foo.go
+++ b/example/foo.go
@@ -9,17 +9,20 @@ type UnixMillis int64
 type JsonMap map[string]interface{}
 type DoubleAlias JsonMap
 
+type InterfaceResponse interface{}
+
 type FooResponse struct {
-	ID           string                 `json:"id"`
-	StartDate    time.Time              `json:"startDate"`
-	EndDate      UnixMillis             `json:"endDate"`
-	Count        int64                  `json:"count"`
-	Msg          json.RawMessage        `json:"msg"`
-	InnerFoos    []InnerFoo             `json:"foo"`
-	Environments map[string]Environment `json:"environments"`
-	FreeForm     interface{}            `json:"freeForm"`
-	JsonMap      JsonMap                `json:"jsonMap"`
-	DoubleAlias  DoubleAlias            `json:"doubleAlias"`
+	ID            string                 `json:"id"`
+	StartDate     time.Time              `json:"startDate"`
+	EndDate       UnixMillis             `json:"endDate"`
+	Count         int64                  `json:"count"`
+	Msg           json.RawMessage        `json:"msg"`
+	InnerFoos     []InnerFoo             `json:"foo"`
+	Environments  map[string]Environment `json:"environments"`
+	FreeForm      interface{}            `json:"freeForm"`
+	JsonMap       JsonMap                `json:"jsonMap"`
+	DoubleAlias   DoubleAlias            `json:"doubleAlias"`
+	InterfaceBlah InterfaceResponse      `json:"interfaceBlah"`
 }
 
 type Environment struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/goas
 
-go 1.12
+go 1.15
 
 require (
 	github.com/iancoleman/orderedmap v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,6 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/parser.go
+++ b/parser.go
@@ -1208,6 +1208,11 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string) (*SchemaOb
 		} else if isGoTypeOASType(typeAsString) {
 			propertySchema.Type = goTypesOASTypes[typeAsString]
 		}
+	} else if _, ok := typeSpec.Type.(*ast.InterfaceType); ok {
+		// type points to an interface, the most we can do is give it an object type..
+		schemaObject.Type = "object"
+		// free form object since the interface can be "anything"
+		schemaObject.AdditionalProperties = &SchemaObject{}
 	}
 
 	// register schema object in spec tree if it doesn't exist

--- a/parser_test.go
+++ b/parser_test.go
@@ -191,6 +191,9 @@ func TestExample(t *testing.T) {
                     },
                     "doubleAlias": {
                         "$ref": "#/components/schemas/DoubleAlias"
+                    },
+                    "interfaceBlah": {
+                        "$ref": "#/components/schemas/InterfaceResponse"
                     }
                 }
             },
@@ -204,6 +207,10 @@ func TestExample(t *testing.T) {
                         "type": "string"
                     }
                 }
+            },
+            "InterfaceResponse": {
+                "type": "object",
+                "additionalProperties": {}
             },
             "JsonMap": {
                 "type": "object",


### PR DESCRIPTION
Adds support to be able to reference interfaces..

Before this PR, the interface would get parsed as:
```
 "InterfaceResponse": {}
```
Now it gets parsed as:
```
 "InterfaceResponse": {
                "type": "object",
                "additionalProperties": {}
            },
```