### PR TITLE
add object type to interfaces

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1237,7 +1237,9 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 		// type points to an interface, the most we can do is give it an object type..
 		schemaObject.Type = "object"
 		// free form object since the interface can be "anything"
-		schemaObject.AdditionalProperties = &SchemaObject{}
+		schemaObject.AdditionalProperties = &SchemaObject{
+			Type: "object",
+		}
 	}
 
 	// we don't want to register 3rd party library types

--- a/parser_test.go
+++ b/parser_test.go
@@ -225,7 +225,9 @@ func TestExample(t *testing.T) {
             },
             "InterfaceResponse": {
                 "type": "object",
-                "additionalProperties": {}
+                "additionalProperties": {
+                    "type": "object"
+                }
             },
             "JsonMap": {
                 "type": "object",


### PR DESCRIPTION
Add the `"type": "object"` to interface outputs. This isn't strictly necessarily according to openapi 3.0 standards, but swagger-gen isn't playing nice without it.