### PR TITLE
keep siblings to $ref

### DIFF
--- a/example/foo.go
+++ b/example/foo.go
@@ -28,6 +28,7 @@ type FooResponse struct {
 	DoubleAlias   DoubleAlias            `json:"doubleAlias"`
 	InterfaceBlah InterfaceResponse      `json:"interfaceBlah"`
 	Instruction   Instruction            `json:"instruction"`
+	BsonPtr       *BsonID                `json:"bsonPtr,omitempty" example:"blah blah blah"`
 }
 
 type Environment struct {

--- a/parser.go
+++ b/parser.go
@@ -1464,10 +1464,6 @@ func parseStructTags(astField *ast.Field, structSchema *SchemaObject, fieldSchem
 			default:
 				fieldSchema.Example = tag
 			}
-
-			if fieldSchema.Example != nil && len(fieldSchema.Ref) != 0 {
-				fieldSchema.Ref = ""
-			}
 		}
 
 		if _, ok := astFieldTag.Lookup("required"); ok || isRequired {

--- a/parser_test.go
+++ b/parser_test.go
@@ -203,6 +203,10 @@ func TestExample(t *testing.T) {
                     },
                     "instruction": {
                         "$ref": "#/components/schemas/Instruction"
+                    },
+                    "bsonPtr": {
+                        "example": "blah blah blah",
+                        "$ref": "#/components/schemas/BsonID"
                     }
                 }
             },


### PR DESCRIPTION
In the case where both a `$ref` and siblings are defined, this removes the previous author's code to omit the `$ref`. As a result, both siblings and `$ref` will be kept.