### PR TITLE
Handle int64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 glide.lock
 .idea/
+goas

--- a/parser.go
+++ b/parser.go
@@ -1153,7 +1153,10 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 	}
 
 	if isGoTypeOASType(p.getTypeAsString(typeSpec.Type)) && schemaObject.Ref == "" {
-		schemaObject.Type = goTypesOASTypes[p.getTypeAsString(typeSpec.Type)]
+		typeAsString := p.getTypeAsString(typeSpec.Type)
+		schemaObject.Type = goTypesOASTypes[typeAsString]
+		checkFormatInt64(typeAsString, &schemaObject)
+
 	} else if astIdent, ok := typeSpec.Type.(*ast.Ident); ok {
 		// this is for type aliases to custom types
 		newSchema, err := p.parseSchemaObject(pkgPath, pkgName, astIdent.Name, true)
@@ -1308,6 +1311,7 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 			}
 		} else if isGoTypeOASType(typeAsString) {
 			fieldSchema.Type = goTypesOASTypes[typeAsString]
+			checkFormatInt64(typeAsString, fieldSchema)
 		}
 		// for embedded fields
 		if len(astField.Names) == 0 {

--- a/parser_test.go
+++ b/parser_test.go
@@ -159,7 +159,8 @@ func TestExample(t *testing.T) {
                         "$ref": "#/components/schemas/UnixMillis"
                     },
                     "count": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "msg": {
                         "type": "object"
@@ -240,7 +241,8 @@ func TestExample(t *testing.T) {
                 }
             },
             "UnixMillis": {
-                "type": "integer"
+                "type": "integer",
+                "format": "int64"
             }
         },
         "securitySchemes": {

--- a/util.go
+++ b/util.go
@@ -162,3 +162,10 @@ func genSchemeaObjectID(pkgName, typeName string) string {
 func replaceBackslash(origin string) string {
 	return strings.ReplaceAll(origin, "\\", "/")
 }
+
+// checkFormatInt64 will see if the type is int64 and add to Format property if true
+func checkFormatInt64(typeName string, schemaObject *SchemaObject) {
+	if typeName == "int64" {
+		schemaObject.Format = "int64"
+	}
+}


### PR DESCRIPTION
There is an error thrown for `int64` because it requires the `format` property.