### PR TITLE
Dob/interface fix

### DIFF
--- a/example/foo.go
+++ b/example/foo.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"encoding/json"
-	"gopkg.in/mgo.v2/bson"
 	"time"
+
+	"gopkg.in/mgo.v2/bson"
 )
 
 type UnixMillis int64
@@ -19,7 +20,7 @@ type FooResponse struct {
 	ID            string                 `json:"id"`
 	StartDate     time.Time              `json:"startDate"`
 	EndDate       UnixMillis             `json:"endDate"`
-	Count         int64                  `json:"count"`
+	Count         int64                  `json:"count" example:"6"`
 	Msg           json.RawMessage        `json:"msg"`
 	InnerFoos     []InnerFoo             `json:"foo"`
 	Environments  map[string]Environment `json:"environments"`
@@ -29,6 +30,7 @@ type FooResponse struct {
 	InterfaceBlah InterfaceResponse      `json:"interfaceBlah"`
 	Instruction   Instruction            `json:"instruction"`
 	BsonPtr       *BsonID                `json:"bsonPtr,omitempty" example:"blah blah blah"`
+	RandomBool    bool                   `json:"randomBool,omitempty" example:"true"`
 }
 
 type Environment struct {

--- a/oas.go
+++ b/oas.go
@@ -136,7 +136,7 @@ type SchemaObject struct {
 	FieldName          string              `json:"-"` // For goas
 	DisabledFieldNames map[string]struct{} `json:"-"` // For goas
 
-	Type                 string                 `json:"type,omitempty"`
+	Type                 *string                `json:"type,omitempty"`
 	Format               string                 `json:"format,omitempty"`
 	Required             []string               `json:"required,omitempty"`
 	Properties           *orderedmap.OrderedMap `json:"properties,omitempty"`

--- a/parser.go
+++ b/parser.go
@@ -1445,7 +1445,9 @@ func parseStructTags(astField *ast.Field, structSchema *SchemaObject, fieldSchem
 		}
 
 		if tag := astFieldTag.Get("example"); tag != "" {
-			if fieldSchema.Type != nil {
+			if fieldSchema.Type == nil {
+				fieldSchema.Example = tag
+			} else {
 				switch *fieldSchema.Type {
 				case "boolean":
 					fieldSchema.Example, _ = strconv.ParseBool(tag)

--- a/parser.go
+++ b/parser.go
@@ -57,6 +57,12 @@ type pkg struct {
 	Path string
 }
 
+var (
+	objectType = "object"
+	stringType = "string"
+	arrayType  = "array"
+)
+
 func newParser(modulePath, mainFilePath, handlerPath string, debug bool) (*parser, error) {
 	p := &parser{
 		CorePkgs:                map[string]bool{},
@@ -789,7 +795,7 @@ func (p *parser) parseParamComment(pkgPath, pkgName string, operation *Operation
 				Content: map[string]*MediaTypeObject{
 					ContentTypeForm: &MediaTypeObject{
 						Schema: SchemaObject{
-							Type:       "object",
+							Type:       &objectType,
 							Properties: orderedmap.New(),
 						},
 					},
@@ -799,22 +805,23 @@ func (p *parser) parseParamComment(pkgPath, pkgName string, operation *Operation
 		}
 		if in == "file" {
 			operation.RequestBody.Content[ContentTypeForm].Schema.Properties.Set(name, &SchemaObject{
-				Type:        "string",
+				Type:        &stringType,
 				Format:      "binary",
 				Description: description,
 			})
 		} else if in == "files" {
 			operation.RequestBody.Content[ContentTypeForm].Schema.Properties.Set(name, &SchemaObject{
-				Type: "array",
+				Type: &arrayType,
 				Items: &SchemaObject{
-					Type:   "string",
+					Type:   &stringType,
 					Format: "binary",
 				},
 				Description: description,
 			})
 		} else if isGoTypeOASType(goType) {
+			localGoType := goTypesOASTypes[goType]
 			operation.RequestBody.Content[ContentTypeForm].Schema.Properties.Set(name, &SchemaObject{
-				Type:        goTypesOASTypes[goType],
+				Type:        &localGoType,
 				Format:      goTypesOASFormats[goType],
 				Description: description,
 			})
@@ -841,8 +848,9 @@ func (p *parser) parseParamComment(pkgPath, pkgName string, operation *Operation
 			}
 			operation.Parameters = append(operation.Parameters, parameterObject)
 		} else if isGoTypeOASType(goType) {
+			localGoType := goTypesOASTypes[goType]
 			parameterObject.Schema = &SchemaObject{
-				Type:        goTypesOASTypes[goType],
+				Type:        &localGoType,
 				Format:      goTypesOASFormats[goType],
 				Description: description,
 			}
@@ -874,7 +882,7 @@ func (p *parser) parseParamComment(pkgPath, pkgName string, operation *Operation
 		if isBasicGoType(typeName) {
 			operation.RequestBody.Content[ContentTypeJson] = &MediaTypeObject{
 				Schema: SchemaObject{
-					Type: "string",
+					Type: &stringType,
 				},
 			}
 		} else {
@@ -947,7 +955,7 @@ func (p *parser) parseResponseComment(pkgPath, pkgName string, operation *Operat
 			if isBasicGoType(typeName) {
 				responseObject.Content[ContentTypeText] = &MediaTypeObject{
 					Schema: SchemaObject{
-						Type: "string",
+						Type: &stringType,
 					},
 				}
 			} else {
@@ -1042,7 +1050,7 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 
 	// handler basic and some specific typeName
 	if strings.HasPrefix(typeName, "[]") {
-		schemaObject.Type = "array"
+		schemaObject.Type = &arrayType
 		itemTypeName := typeName[2:]
 		schema, ok := p.KnownIDSchema[genSchemeaObjectID(pkgName, itemTypeName)]
 		if ok {
@@ -1055,7 +1063,7 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 		}
 		return &schemaObject, nil
 	} else if strings.HasPrefix(typeName, "map[]") {
-		schemaObject.Type = "object"
+		schemaObject.Type = &objectType
 		itemTypeName := typeName[5:]
 		schema, ok := p.KnownIDSchema[genSchemeaObjectID(pkgName, itemTypeName)]
 		if ok {
@@ -1069,14 +1077,15 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 		schemaObject.AdditionalProperties = schemaProperty
 		return &schemaObject, nil
 	} else if typeName == "time.Time" {
-		schemaObject.Type = "string"
+		schemaObject.Type = &stringType
 		schemaObject.Format = "date-time"
 		return &schemaObject, nil
 	} else if strings.HasPrefix(typeName, "interface{}") {
-		schemaObject.Type = "object"
+		schemaObject.Type = nil
 		return &schemaObject, nil
 	} else if isGoTypeOASType(typeName) {
-		schemaObject.Type = goTypesOASTypes[typeName]
+		localGoType := goTypesOASTypes[typeName]
+		schemaObject.Type = &localGoType
 		return &schemaObject, nil
 	}
 
@@ -1137,7 +1146,7 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 			if !exist {
 				if p.CorePkgs[guessPkgName] == true {
 					p.debugf("Ignoring missing type %s in core package %s", guessTypeName, guessPkgName)
-					schemaObject.Type = "object"
+					schemaObject.Type = &objectType
 					return &schemaObject, nil
 				}
 
@@ -1154,7 +1163,8 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 
 	if isGoTypeOASType(p.getTypeAsString(typeSpec.Type)) && schemaObject.Ref == "" {
 		typeAsString := p.getTypeAsString(typeSpec.Type)
-		schemaObject.Type = goTypesOASTypes[typeAsString]
+		localGoType := goTypesOASTypes[typeAsString]
+		schemaObject.Type = &localGoType
 		checkFormatInt64(typeAsString, &schemaObject)
 
 	} else if astIdent, ok := typeSpec.Type.(*ast.Ident); ok {
@@ -1167,12 +1177,12 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 		schemaObject.Properties = newSchema.Properties
 		schemaObject.AdditionalProperties = newSchema.AdditionalProperties
 	} else if astStructType, ok := typeSpec.Type.(*ast.StructType); ok {
-		schemaObject.Type = "object"
+		schemaObject.Type = &objectType
 		if astStructType.Fields != nil {
 			p.parseSchemaPropertiesFromStructFields(pkgPath, pkgName, &schemaObject, astStructType.Fields.List)
 		}
 	} else if astArrayType, ok := typeSpec.Type.(*ast.ArrayType); ok {
-		schemaObject.Type = "array"
+		schemaObject.Type = &arrayType
 		schemaObject.Items = &SchemaObject{}
 		typeAsString := p.getTypeAsString(astArrayType.Elt)
 		typeAsString = strings.TrimLeft(typeAsString, "*")
@@ -1189,10 +1199,11 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 				}
 			}
 		} else if isGoTypeOASType(typeAsString) {
-			schemaObject.Items.Type = goTypesOASTypes[typeAsString]
+			localGoType := goTypesOASTypes[typeAsString]
+			schemaObject.Items.Type = &localGoType
 		}
 	} else if astMapType, ok := typeSpec.Type.(*ast.MapType); ok {
-		schemaObject.Type = "object"
+		schemaObject.Type = &objectType
 		propertySchema := &SchemaObject{}
 		schemaObject.AdditionalProperties = propertySchema
 		typeAsString := p.getTypeAsString(astMapType.Value)
@@ -1209,7 +1220,8 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 				}
 			}
 		} else if isGoTypeOASType(typeAsString) {
-			propertySchema.Type = goTypesOASTypes[typeAsString]
+			localGoType := goTypesOASTypes[typeAsString]
+			propertySchema.Type = &localGoType
 		}
 	} else if selectorType, ok := typeSpec.Type.(*ast.SelectorExpr); ok {
 		// this case is for referencing third party packages.
@@ -1238,10 +1250,10 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 		}
 	} else if _, ok := typeSpec.Type.(*ast.InterfaceType); ok {
 		// type points to an interface, the most we can do is give it an object type..
-		schemaObject.Type = "object"
+		schemaObject.Type = &objectType
 		// free form object since the interface can be "anything"
 		schemaObject.AdditionalProperties = &SchemaObject{
-			Type: "object",
+			Type: &objectType,
 		}
 	}
 
@@ -1310,7 +1322,8 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 				}
 			}
 		} else if isGoTypeOASType(typeAsString) {
-			fieldSchema.Type = goTypesOASTypes[typeAsString]
+			localGoType := goTypesOASTypes[typeAsString]
+			fieldSchema.Type = &localGoType
 			checkFormatInt64(typeAsString, fieldSchema)
 		}
 		// for embedded fields
@@ -1432,41 +1445,43 @@ func parseStructTags(astField *ast.Field, structSchema *SchemaObject, fieldSchem
 		}
 
 		if tag := astFieldTag.Get("example"); tag != "" {
-			switch fieldSchema.Type {
-			case "boolean":
-				fieldSchema.Example, _ = strconv.ParseBool(tag)
-			case "integer":
-				fieldSchema.Example, _ = strconv.Atoi(tag)
-			case "number":
-				fieldSchema.Example, _ = strconv.ParseFloat(tag, 64)
-			case "array":
-				b, err := json.RawMessage(tag).MarshalJSON()
-				if err != nil {
-					fieldSchema.Example = "invalid example"
-				} else {
-					sliceOfInterface := []interface{}{}
-					err := json.Unmarshal(b, &sliceOfInterface)
+			if fieldSchema.Type != nil {
+				switch *fieldSchema.Type {
+				case "boolean":
+					fieldSchema.Example, _ = strconv.ParseBool(tag)
+				case "integer":
+					fieldSchema.Example, _ = strconv.Atoi(tag)
+				case "number":
+					fieldSchema.Example, _ = strconv.ParseFloat(tag, 64)
+				case "array":
+					b, err := json.RawMessage(tag).MarshalJSON()
 					if err != nil {
 						fieldSchema.Example = "invalid example"
 					} else {
-						fieldSchema.Example = sliceOfInterface
+						sliceOfInterface := []interface{}{}
+						err := json.Unmarshal(b, &sliceOfInterface)
+						if err != nil {
+							fieldSchema.Example = "invalid example"
+						} else {
+							fieldSchema.Example = sliceOfInterface
+						}
 					}
-				}
-			case "object":
-				b, err := json.RawMessage(tag).MarshalJSON()
-				if err != nil {
-					fieldSchema.Example = "invalid example"
-				} else {
-					mapOfInterface := map[string]interface{}{}
-					err := json.Unmarshal(b, &mapOfInterface)
+				case "object":
+					b, err := json.RawMessage(tag).MarshalJSON()
 					if err != nil {
 						fieldSchema.Example = "invalid example"
 					} else {
-						fieldSchema.Example = mapOfInterface
+						mapOfInterface := map[string]interface{}{}
+						err := json.Unmarshal(b, &mapOfInterface)
+						if err != nil {
+							fieldSchema.Example = "invalid example"
+						} else {
+							fieldSchema.Example = mapOfInterface
+						}
 					}
+				default:
+					fieldSchema.Example = tag
 				}
-			default:
-				fieldSchema.Example = tag
 			}
 		}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -130,9 +130,7 @@ func TestExample(t *testing.T) {
             },
             "DoubleAlias": {
                 "type": "object",
-                "additionalProperties": {
-                    "type": "object"
-                }
+                "additionalProperties": {}
             },
             "Environment": {
                 "type": "object",
@@ -160,7 +158,8 @@ func TestExample(t *testing.T) {
                     },
                     "count": {
                         "type": "integer",
-                        "format": "int64"
+                        "format": "int64",
+                        "example": 6
                     },
                     "msg": {
                         "type": "object"
@@ -190,9 +189,7 @@ func TestExample(t *testing.T) {
                             }
                         }
                     },
-                    "freeForm": {
-                        "type": "object"
-                    },
+                    "freeForm": {},
                     "jsonMap": {
                         "$ref": "#/components/schemas/JsonMap"
                     },
@@ -208,6 +205,10 @@ func TestExample(t *testing.T) {
                     "bsonPtr": {
                         "example": "blah blah blah",
                         "$ref": "#/components/schemas/BsonID"
+                    },
+                    "randomBool": {
+                        "example": true,
+                        "type": "boolean"
                     }
                 }
             },
@@ -224,9 +225,7 @@ func TestExample(t *testing.T) {
             },
             "Instruction": {
                 "type": "object",
-                "additionalProperties": {
-                    "type": "object"
-                }
+                "additionalProperties": {}
             },
             "InterfaceResponse": {
                 "type": "object",
@@ -236,9 +235,7 @@ func TestExample(t *testing.T) {
             },
             "JsonMap": {
                 "type": "object",
-                "additionalProperties": {
-                    "type": "object"
-                }
+                "additionalProperties": {}
             },
             "UnixMillis": {
                 "type": "integer",


### PR DESCRIPTION
We need to generate `{}` for empty interfaces so that we accept any time. Without the type being a pointer to a string there's no easy way to pass in `nil` so that when the JSON is marshalled it is a null JSON value:
`Pointer values encode as the value pointed to. A nil pointer encodes as the null JSON value.` https://golang.org/pkg/encoding/json/#Marshal

Updated tests to also verify examples work for multiple different values because this change had an effect on the logic for parsing examples.