### PR TITLE
Add OperatorId support

### DIFF
--- a/example/foo.go
+++ b/example/foo.go
@@ -39,6 +39,7 @@ type Environment struct {
 
 // @Title Get all foos
 // @Description Get all foos
+// @OperationId getAllFoos
 // @Route /api/v2/foo [get]
 // @Success 200 object FooResponse "Successful foo response"
 // @Failure 401 "Invalid access token"

--- a/oas.go
+++ b/oas.go
@@ -77,7 +77,7 @@ type OperationObject struct {
 	Description string             `json:"description,omitempty"`
 	Parameters  []ParameterObject  `json:"parameters,omitempty"`
 	RequestBody *RequestBodyObject `json:"requestBody,omitempty"`
-
+	OperationID string             `json:"operationId,omitempty"`
 	// Tags
 	// ExternalDocs
 	// OperationID

--- a/parser.go
+++ b/parser.go
@@ -744,6 +744,8 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			operation.Summary = strings.TrimSpace(comment[len(attribute):])
 		case "@description":
 			operation.Description = strings.Join([]string{operation.Description, strings.TrimSpace(comment[len(attribute):])}, " ")
+		case "@operationid":
+			operation.OperationID = strings.TrimSpace(comment[len(attribute):])
 		case "@param":
 			err = p.parseParamComment(pkgPath, pkgName, operation, strings.TrimSpace(comment[len(attribute):]))
 		case "@success", "@failure":

--- a/parser_test.go
+++ b/parser_test.go
@@ -67,7 +67,8 @@ func TestExample(t *testing.T) {
                     }
                 },
                 "summary": "Get all foos",
-                "description": " Get all foos"
+                "description": " Get all foos",
+                "operationId": "getAllFoos"
             },
             "put": {
                 "responses": {


### PR DESCRIPTION
With this change you can now add the parameter `@OperationId` to routes to generate user-friendly names.

https://swagger.io/docs/specification/paths-and-operations/