### PR TITLE
Support ref descriptions

### DIFF
--- a/oas.go
+++ b/oas.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 
 	"github.com/iancoleman/orderedmap"
@@ -56,6 +57,9 @@ type reference struct {
 
 func (r ReffableString) MarshalJSON() ([]byte, error) {
 	if strings.HasPrefix(r.Value, "$ref:") {
+		if r.Value == "$ref:" {
+			return nil, errors.New("$ref is missing URL")
+		}
 		// encode as a reference object instead of a string
 		return json.Marshal(reference{Ref: r.Value[5:]})
 	}

--- a/oas.go
+++ b/oas.go
@@ -1,6 +1,11 @@
 package main
 
-import "github.com/iancoleman/orderedmap"
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/iancoleman/orderedmap"
+)
 
 const (
 	OpenAPIVersion = "3.0.0"
@@ -31,12 +36,30 @@ type ServerObject struct {
 }
 
 type InfoObject struct {
-	Title          string         `json:"title"`
-	Description    string         `json:"description,omitempty"`
-	TermsOfService string         `json:"termsOfService,omitempty"`
-	Contact        *ContactObject `json:"contact,omitempty"`
-	License        *LicenseObject `json:"license,omitempty"`
-	Version        string         `json:"version"`
+	Title          string          `json:"title"`
+	Description    *ReffableString `json:"description,omitempty"`
+	TermsOfService string          `json:"termsOfService,omitempty"`
+	Contact        *ContactObject  `json:"contact,omitempty"`
+	License        *LicenseObject  `json:"license,omitempty"`
+	Version        string          `json:"version"`
+}
+
+// Wrapper for a string that may be of the form `$ref:foo`
+// denoting it should be json encoded as `{ "$ref": "foo"}`
+type ReffableString struct {
+	Value string
+}
+
+type reference struct {
+	Ref string `json:"$ref"`
+}
+
+func (r ReffableString) MarshalJSON() ([]byte, error) {
+	if strings.HasPrefix(r.Value, "$ref:") {
+		// encode as a reference object instead of a string
+		return json.Marshal(reference{Ref: r.Value[5:]})
+	}
+	return json.Marshal(r.Value)
 }
 
 type ContactObject struct {

--- a/oas.go
+++ b/oas.go
@@ -292,6 +292,6 @@ type SecuritySchemeOauthFlowObject struct {
 }
 
 type TagDefinition struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
+	Name        string          `json:"name"`
+	Description *ReffableString `json:"description,omitempty"`
 }

--- a/oas.go
+++ b/oas.go
@@ -45,7 +45,7 @@ type InfoObject struct {
 }
 
 // Wrapper for a string that may be of the form `$ref:foo`
-// denoting it should be json encoded as `{ "$ref": "foo"}`
+// denoting it should be json encoded as `{ "$ref": "foo" }`
 type ReffableString struct {
 	Value string
 }

--- a/oas_test.go
+++ b/oas_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReffableString(t *testing.T) {
+	t.Run("marshals a string", func(t *testing.T) {
+		result, err := json.Marshal(&ReffableString{Value: "Foobarbazington Esq."})
+
+		require.NoError(t, err)
+		require.Equal(t, ([]byte)("\"Foobarbazington Esq.\""), result)
+	})
+
+	t.Run("marshals an object", func(t *testing.T) {
+		result, err := json.Marshal(&ReffableString{Value: "$ref:foo/bar/baz"})
+
+		require.NoError(t, err)
+		require.Equal(t, ([]byte)("{\"$ref\":\"foo/bar/baz\"}"), result)
+	})
+
+	t.Run("missing url", func(t *testing.T) {
+		_, err := json.Marshal(&ReffableString{Value: "$ref:"})
+
+		require.Error(t, err)
+	})
+}

--- a/oas_test.go
+++ b/oas_test.go
@@ -12,14 +12,14 @@ func TestReffableString(t *testing.T) {
 		result, err := json.Marshal(&ReffableString{Value: "Foobarbazington Esq."})
 
 		require.NoError(t, err)
-		require.Equal(t, ([]byte)("\"Foobarbazington Esq.\""), result)
+		require.Equal(t, "\"Foobarbazington Esq.\"", string(result))
 	})
 
 	t.Run("marshals an object", func(t *testing.T) {
 		result, err := json.Marshal(&ReffableString{Value: "$ref:foo/bar/baz"})
 
 		require.NoError(t, err)
-		require.Equal(t, ([]byte)("{\"$ref\":\"foo/bar/baz\"}"), result)
+		require.Equal(t, "{\"$ref\":\"foo/bar/baz\"}", string(result))
 	})
 
 	t.Run("missing url", func(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -441,7 +441,7 @@ func parseTags(comment string) (*TagDefinition, error) {
 	}
 	tag := TagDefinition{Name: matches[0][1]}
 	if len(matches) > 1 {
-		tag.Description = matches[1][1]
+		tag.Description = &ReffableString{Value: matches[1][1]}
 	}
 
 	return &tag, nil

--- a/parser.go
+++ b/parser.go
@@ -289,7 +289,10 @@ func (p *parser) parseInfo() error {
 				case "@title":
 					p.OpenAPI.Info.Title = value
 				case "@description":
-					p.OpenAPI.Info.Description = value
+					if p.OpenAPI.Info.Description == nil {
+						p.OpenAPI.Info.Description = &ReffableString{}
+					}
+					p.OpenAPI.Info.Description.Value = value
 				case "@termsofserviceurl":
 					p.OpenAPI.Info.TermsOfService = value
 				case "@contactname":

--- a/parser_test.go
+++ b/parser_test.go
@@ -66,7 +66,7 @@ func Test_infoDescriptionRef(t *testing.T) {
 	result, err := json.Marshal(p.OpenAPI.Info.Description)
 
 	require.NoError(t, err)
-	require.Equal(t, []byte("{\"$ref\":\"http://dopeoplescroll.com/\"}"), result)
+	require.Equal(t, "{\"$ref\":\"http://dopeoplescroll.com/\"}", string(result))
 }
 
 func Test_parseTags(t *testing.T) {
@@ -81,7 +81,15 @@ func Test_parseTags(t *testing.T) {
 		result, err := parseTags("@Tags \"Foobar\" \"Barbaz\"")
 
 		require.NoError(t, err)
-		require.Equal(t, &TagDefinition{Name: "Foobar", Description: "Barbaz"}, result)
+		require.Equal(t, &TagDefinition{Name: "Foobar", Description: &ReffableString{Value: "Barbaz"}}, result)
+	})
+
+	t.Run("name and description including ref ", func(t *testing.T) {
+		result, err := parseTags("@Tags \"Foobar\" \"$ref:path/to/baz\"")
+		require.NoError(t, err)
+		b, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.Equal(t, "{\"name\":\"Foobar\",\"description\":{\"$ref\":\"path/to/baz\"}}", string(b))
 	})
 
 	t.Run("invalid tag", func(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -57,3 +57,14 @@ func Test_parseRouteComment(t *testing.T) {
 	duplicateError := p.parseRouteComment(operation, "@Router v2/foo/bar [get]")
 	require.Error(t, duplicateError)
 }
+
+func Test_infoDescriptionRef(t *testing.T) {
+	p, err := newParser("example/", "example/main.go", "", false)
+	require.NoError(t, err)
+	p.OpenAPI.Info.Description = &ReffableString{Value: "$ref:http://dopeoplescroll.com/"}
+
+	result, err := json.Marshal(p.OpenAPI.Info.Description)
+
+	require.NoError(t, err)
+	require.Equal(t, []byte("{\"$ref\":\"http://dopeoplescroll.com/\"}"), result)
+}


### PR DESCRIPTION
Lets you use an openAPI `$ref` as your info section description instead of a string literal.

This is only second contribution to a go project ever, so please let me know if I'm doing anything obviously incorrect or unidiomatic :P

Implemented this by allowing you to provide your description annotation of the form,

```
@description $ref:url/goes/here
```

Which will be serialized into JSON as

```
  "description": {
    "$ref": "url/goes/here"
  }
```

Only the description of the info section has been updated to take advantage of this, but if we are happy with this approach we can update other reffable descriptions to support this as well.

Included a unit test.

## Testing

Update the annotation in `gonfalon.go` in `gonfalon` to include something prefixed by `$ref`, e.g.

```diff
--- a/gonfalon.go
+++ b/gonfalon.go
@@ -90,7 +90,7 @@ import (
 
  // @Version 2.0
  // @Title LaunchDarkly REST API
- // @Description Build custom integrations with the LaunchDarkly REST API
+ // @Description $ref:foo
  // @ContactName LaunchDarkly Technical Support Team
  // @ContactEmail support@launchdarkly.com
  // @ContactURL https://support.launchdarkly.com
```

Running this branch of `goas` should yield an openAPI spec that includes `info.description` as an object containing the intended reference rather than a string, e.g.

```
{
  "openapi": "3.0.0",
  "info": {
    "title": "LaunchDarkly REST API",
    "description": {
      "$ref": "foo"
    },
   ...
```