### PR TITLE
Support openAPI tags property

### DIFF
--- a/example/example.json
+++ b/example/example.json
@@ -294,5 +294,14 @@
         "write"
       ]
     }
+  ],
+  "tags": [
+    {
+      "name": "Foo"
+    },
+    {
+      "name": "Bar",
+      "description": "Baz"
+    }
   ]
 }

--- a/example/main.go
+++ b/example/main.go
@@ -11,6 +11,8 @@ package main
 // @Server https://app.launchdarkly.com
 // @Security ApiKey read write
 // @SecurityScheme ApiKey apiKey header Authorization
+// @Tags "Foo"
+// @Tags "Bar" "Baz"
 
 func main() {
 

--- a/oas.go
+++ b/oas.go
@@ -19,7 +19,7 @@ type OpenAPIObject struct {
 	Components ComponentsOjbect      `json:"components,omitempty"` // Required for Authorization header
 	Security   []map[string][]string `json:"security,omitempty"`
 
-	// Tags
+	Tags []TagDefinition `json:"tags,omitempty"`
 	// ExternalDocs
 }
 
@@ -262,4 +262,9 @@ type SecuritySchemeOauthFlowObject struct {
 	AuthorizationUrl string            `json:"authorizationUrl,omitempty"`
 	TokenUrl         string            `json:"tokenUrl,omitempty"`
 	Scopes           map[string]string `json:"scopes"`
+}
+
+type TagDefinition struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
 }

--- a/parser.go
+++ b/parser.go
@@ -390,16 +390,13 @@ func (p *parser) parseInfo() error {
 
 					oauthScopes[fields[0]][fields[1]] = strings.Join(fields[2:], " ")
 				case "@tags":
-					re, _ := regexp.Compile("\"([^\"]*)\"")
-					matches := re.FindAllStringSubmatch(comment, -1)
-					if len(matches) == 0 || len(matches[0]) == 1 {
-						return fmt.Errorf("Expected: @Tags \"<name>\" [\"<description>\"] Received: %s", comment)
+					t, err := parseTags(comment)
+
+					if err != nil {
+						return err
 					}
-					tag := TagDefinition{Name: matches[0][1]}
-					if len(matches) > 1 {
-						tag.Description = matches[1][1]
-					}
-					p.OpenAPI.Tags = append(p.OpenAPI.Tags, tag)
+
+					p.OpenAPI.Tags = append(p.OpenAPI.Tags, *t)
 				}
 			}
 		}
@@ -431,6 +428,20 @@ func (p *parser) parseInfo() error {
 	}
 
 	return nil
+}
+
+func parseTags(comment string) (*TagDefinition, error) {
+	re, _ := regexp.Compile("\"([^\"]*)\"")
+	matches := re.FindAllStringSubmatch(comment, -1)
+	if len(matches) == 0 || len(matches[0]) == 1 {
+		return nil, fmt.Errorf("Expected: @Tags \"<name>\" [\"<description>\"] Received: %s", comment)
+	}
+	tag := TagDefinition{Name: matches[0][1]}
+	if len(matches) > 1 {
+		tag.Description = matches[1][1]
+	}
+
+	return &tag, nil
 }
 
 func (p *parser) parseModule() error {

--- a/parser.go
+++ b/parser.go
@@ -389,6 +389,17 @@ func (p *parser) parseInfo() error {
 					}
 
 					oauthScopes[fields[0]][fields[1]] = strings.Join(fields[2:], " ")
+				case "@tags":
+					re, _ := regexp.Compile("\"([^\"]*)\"")
+					matches := re.FindAllStringSubmatch(comment, -1)
+					if len(matches) == 0 || len(matches[0]) == 1 {
+						return fmt.Errorf("Expected: @Tags \"<name>\" [\"<description>\"] Received: %s", comment)
+					}
+					tag := TagDefinition{Name: matches[0][1]}
+					if len(matches) > 1 {
+						tag.Description = matches[1][1]
+					}
+					p.OpenAPI.Tags = append(p.OpenAPI.Tags, tag)
 				}
 			}
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -57,3 +57,25 @@ func Test_parseRouteComment(t *testing.T) {
 	duplicateError := p.parseRouteComment(operation, "@Router v2/foo/bar [get]")
 	require.Error(t, duplicateError)
 }
+
+func Test_parseTags(t *testing.T) {
+	t.Run("name", func(t *testing.T) {
+		result, err := parseTags("@Tags \"Foo\"")
+
+		require.NoError(t, err)
+		require.Equal(t, &TagDefinition{Name: "Foo"}, result)
+	})
+
+	t.Run("name and description", func(t *testing.T) {
+		result, err := parseTags("@Tags \"Foobar\" \"Barbaz\"")
+
+		require.NoError(t, err)
+		require.Equal(t, &TagDefinition{Name: "Foobar", Description: "Barbaz"}, result)
+	})
+
+	t.Run("invalid tag", func(t *testing.T) {
+		_, err := parseTags("@Tags Foobar Barbaz")
+
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Adds support for the top level openAPI `tags` property, allowing you to optionally provide tag descriptions, and giving us control over the order that sections will appear in the redocly generated docs.

Support has been added by letting you add any number of `@Tags` annotations at the top level of your spec. See updated test project for example.