### PR TITLE
Goas support for oneOf/anyOf/allOf/not

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ func PostUser() {
 - {required}: `true`, `false`, `required` or `optional`. 
 - {description}: The description of the parameter. Must be quoted.
 
+##### allOf, anyOf, oneOf, not
+
+`allOf`, `anyOf`, `oneOf` and `not` are supported for `body` parameter types. `not` requires a single argument, while the others require one or more. e.g.
+
+```
+@Param user body oneOf(User,string) true "Info of a user."
+```
+
 #### Response
 ```
 @Success  {status}  {jsonType}  {goType}       {description}

--- a/example/example.json
+++ b/example/example.json
@@ -43,9 +43,7 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": [
-          "Foo"
-        ],
+        "tags": ["Foo"],
         "summary": "Get all foos",
         "description": " Get all foos",
         "operationId": "getAllFoos"
@@ -99,12 +97,85 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": [
-          "Foo With Spaces"
-        ],
+        "tags": ["Foo With Spaces"],
         "summary": "Get foos with spaces",
         "description": " Get foos with spaces",
         "operationId": "getFoosWithSpaces"
+      }
+    },
+    "/api/v2/foo/{id}": {
+      "patch": {
+        "responses": {
+          "204": {
+            "description": "No content"
+          },
+          "401": {
+            "description": "Invalid access token"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Invalid resource identifier"
+          }
+        },
+        "summary": "Update foo",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Foo id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "string",
+              "description": "Foo id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "operations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "op": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "count": {
+                        "type": "integer",
+                        "format": "int64"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "operationId": "patchFoo"
       }
     },
     "/api/v2/foo/{id}/inner": {
@@ -157,9 +228,7 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": [
-          "Vfoo"
-        ],
+        "tags": ["Vfoo"],
         "summary": "Get Foo as var",
         "description": " get a foo var"
       }
@@ -179,6 +248,51 @@
         "properties": {
           "name": {
             "type": "string"
+          }
+        }
+      },
+      "example.FooMergePatch": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "example.FooPatchOperation": {
+        "type": "object",
+        "properties": {
+          "op": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "example.FooPatchOperationSet": {
+        "type": "object",
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "op": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       },
@@ -289,10 +403,7 @@
   },
   "security": [
     {
-      "ApiKey": [
-        "read",
-        "write"
-      ]
+      "ApiKey": ["read", "write"]
     }
   ],
   "tags": [

--- a/example/example.json
+++ b/example/example.json
@@ -139,35 +139,10 @@
               "schema": {
                 "oneOf": [
                   {
-                    "type": "object",
-                    "properties": {
-                      "operations": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "op": {
-                              "type": "string"
-                            },
-                            "path": {
-                              "type": "string"
-                            },
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    }
+                    "$ref": "#/components/schemas/example.FooPatchOperationSet"
                   },
                   {
-                    "type": "object",
-                    "properties": {
-                      "count": {
-                        "type": "integer",
-                        "format": "int64"
-                      }
-                    }
+                    "$ref": "#/components/schemas/example.FooMergePatch"
                   }
                 ]
               }

--- a/example/example.json
+++ b/example/example.json
@@ -43,7 +43,9 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": ["Foo"],
+        "tags": [
+          "Foo"
+        ],
         "summary": "Get all foos",
         "description": " Get all foos",
         "operationId": "getAllFoos"
@@ -97,7 +99,9 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": ["Foo With Spaces"],
+        "tags": [
+          "Foo With Spaces"
+        ],
         "summary": "Get foos with spaces",
         "description": " Get foos with spaces",
         "operationId": "getFoosWithSpaces"
@@ -203,7 +207,9 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": ["Vfoo"],
+        "tags": [
+          "Vfoo"
+        ],
         "summary": "Get Foo as var",
         "description": " get a foo var"
       }
@@ -378,7 +384,10 @@
   },
   "security": [
     {
-      "ApiKey": ["read", "write"]
+      "ApiKey": [
+        "read",
+        "write"
+      ]
     }
   ],
   "tags": [

--- a/example/foo.go
+++ b/example/foo.go
@@ -37,6 +37,20 @@ type Environment struct {
 	Name string `json:"name"`
 }
 
+type FooPatchOperation struct {
+	op    string
+	path  string
+	value string
+}
+
+type FooPatchOperationSet struct {
+	operations []FooPatchOperation
+}
+
+type FooMergePatch struct {
+	Count int64 `json:"count"`
+}
+
 // @Title Get all foos
 // @Tag Foo
 // @Description Get all foos
@@ -58,6 +72,19 @@ func getAllFoos() {
 // @Failure 403 "Forbidden"
 // @Failure 404 "Invalid resource identifier"
 func putFoo() {
+
+}
+
+// @Title Update foo
+// @OperationId patchFoo
+// @Route /api/v2/foo/{id} [patch]
+// @Param id path string true "Foo id"
+// @Param foo body oneOf(FooPatchOperationSet,FooMergePatch) true "Foo patch body"
+// @Success 204 "No content"
+// @Failure 401 "Invalid access token"
+// @Failure 403 "Forbidden"
+// @Failure 404 "Invalid resource identifier"
+func patchFoo() {
 
 }
 

--- a/oas.go
+++ b/oas.go
@@ -176,6 +176,11 @@ type SchemaObject struct {
 	// Ref is used when SchemaObject is as a ReferenceObject
 	Ref string `json:"$ref,omitempty"`
 
+	AllOf []*SchemaObject `json:"allOf,omitempty"`
+	OneOf []*SchemaObject `json:"oneOf,omitempty"`
+	AnyOf []*SchemaObject `json:"anyOf,omitempty"`
+	Not   *SchemaObject   `json:"not,omitempty"`
+
 	// Title
 	// MultipleOf
 	// Maximum
@@ -191,10 +196,6 @@ type SchemaObject struct {
 	// MaxProperties
 	// MinProperties
 	// Enum
-	// AllOf
-	// OneOf
-	// AnyOf
-	// Not
 	// Description
 	// Default
 	// Nullable

--- a/parser.go
+++ b/parser.go
@@ -800,6 +800,21 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 	return nil
 }
 
+func shouldParseSchemaObject(typeName string) bool {
+	if typeName == "time.Time" {
+		return true
+	}
+
+	supportedPrefixes := []string{"[]", "map[]", "oneOf(", "anyOf(", "allOf(", "not("}
+	for i := range supportedPrefixes {
+		if strings.HasPrefix(typeName, supportedPrefixes[i]) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (p *parser) parseParamComment(pkgPath, pkgName string, operation *OperationObject, comment string) error {
 	// {name}  {in}  {goType}  {required}  {description}
 	// user    body  User      true        "Info of a user."
@@ -900,7 +915,7 @@ func (p *parser) parseParamComment(pkgPath, pkgName string, operation *Operation
 		}
 	}
 
-	if strings.HasPrefix(goType, "[]") || strings.HasPrefix(goType, "map[]") || goType == "time.Time" {
+	if shouldParseSchemaObject(goType) {
 		schema, err := p.parseSchemaObject(pkgPath, pkgName, goType, true)
 		if err != nil {
 			p.debug("parseResponseComment cannot parse goType", goType)

--- a/parser.go
+++ b/parser.go
@@ -1147,26 +1147,21 @@ func (p *parser) handleCompositeType(pkgPath, pkgName, typeName string) (*Schema
 		sobs = append(sobs, result)
 	}
 
+	sob := &SchemaObject{}
 	switch op {
 	case "not":
-		return &SchemaObject{
-			Not: sobs[0],
-		}, nil
+		sob.Not = sobs[0]
 	case "oneOf":
-		return &SchemaObject{
-			OneOf: sobs,
-		}, nil
+		sob.OneOf = sobs
 	case "anyOf":
-		return &SchemaObject{
-			AnyOf: sobs,
-		}, nil
+		sob.AnyOf = sobs
 	case "allOf":
-		return &SchemaObject{
-			AllOf: sobs,
-		}, nil
+		sob.AllOf = sobs
 	default:
 		return nil, fmt.Errorf("Invalid composite type '%s'", op)
 	}
+
+	return sob, nil
 }
 
 func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register bool) (*SchemaObject, error) {

--- a/parser.go
+++ b/parser.go
@@ -1147,23 +1147,24 @@ func (p *parser) handleCompositeType(pkgPath, pkgName, typeName string) (*Schema
 		sobs = append(sobs, result)
 	}
 
-	if op == "not" {
+	switch op {
+	case "not":
 		return &SchemaObject{
 			Not: sobs[0],
 		}, nil
-	} else if op == "oneOf" {
+	case "oneOf":
 		return &SchemaObject{
 			OneOf: sobs,
 		}, nil
-	} else if op == "anyOf" {
+	case "anyOf":
 		return &SchemaObject{
 			AnyOf: sobs,
 		}, nil
-	} else if op == "allOf" {
+	case "allOf":
 		return &SchemaObject{
 			AllOf: sobs,
 		}, nil
-	} else {
+	default:
 		return nil, fmt.Errorf("Invalid composite type '%s'", op)
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -921,7 +921,7 @@ func (p *parser) parseBodyType(pkgPath, pkgName, typeName string) (*SchemaObject
 	}
 
 	// handle oneOf/anyOf/allOf/not
-	sob, err := p.handleCompositeType(pkgPath, pkgName, typeName)
+	sob, err := p.handleCompoundType(pkgPath, pkgName, typeName)
 	if sob != nil || err != nil {
 		return sob, err
 	}
@@ -1121,7 +1121,7 @@ func trimSplit(csl string) []string {
 	return s
 }
 
-func (p *parser) handleCompositeType(pkgPath, pkgName, typeName string) (*SchemaObject, error) {
+func (p *parser) handleCompoundType(pkgPath, pkgName, typeName string) (*SchemaObject, error) {
 	re := regexp.MustCompile("(oneOf|anyOf|allOf|not)\\(([^\\)]*)\\)")
 	matches := re.FindStringSubmatch(typeName)
 	if len(matches) < 3 {
@@ -1158,7 +1158,7 @@ func (p *parser) handleCompositeType(pkgPath, pkgName, typeName string) (*Schema
 	case "allOf":
 		sob.AllOf = sobs
 	default:
-		return nil, fmt.Errorf("Invalid composite type '%s'", op)
+		return nil, fmt.Errorf("Invalid compound type '%s'", op)
 	}
 
 	return sob, nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -103,37 +103,37 @@ func Test_handleCompositeType(t *testing.T) {
 	t.Run("oneOf", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "oneOf(string,int32)", true)
+		result, err := p.handleCompositeType("./example", "example.com/example", "oneOf(string,[]string)")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
-		require.Equal(t, "{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}", string(s))
+		require.Equal(t, "{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}}]}", string(s))
 	})
 
 	t.Run("anyOf", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "anyOf(string,int32)", true)
+		result, err := p.handleCompositeType("./example", "example.com/example", "anyOf(string,[]string)")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
-		require.Equal(t, "{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}", string(s))
+		require.Equal(t, "{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}}]}", string(s))
 	})
 
 	t.Run("allOf", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "allOf(string,int32)", true)
+		result, err := p.handleCompositeType("./example", "example.com/example", "allOf(string,[]string)")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
-		require.Equal(t, "{\"allOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}", string(s))
+		require.Equal(t, "{\"allOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}}]}", string(s))
 	})
 
 	t.Run("not", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "not(string)", true)
+		result, err := p.handleCompositeType("./example", "example.com/example", "not(string)")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
@@ -143,24 +143,24 @@ func Test_handleCompositeType(t *testing.T) {
 	t.Run("handles whitespace", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "allOf(  string, int32 )", true)
+		result, err := p.handleCompositeType("./example", "example.com/example", "allOf(  string, []string )")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
-		require.Equal(t, "{\"allOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}", string(s))
+		require.Equal(t, "{\"allOf\":[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"type\":\"string\"}}]}", string(s))
 	})
 
 	t.Run("not only accepts 1 arg", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		_, notErr := p.handleCompositeType("./example", "example.com/example", "not(string,int32)", true)
+		_, notErr := p.handleCompositeType("./example", "example.com/example", "not(string,int32)")
 		require.Error(t, notErr)
 	})
 
 	t.Run("error when no args", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		_, notErr := p.handleCompositeType("./example", "example.com/example", "oneOf()", true)
+		_, notErr := p.handleCompositeType("./example", "example.com/example", "oneOf()")
 		require.Error(t, notErr)
 	})
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -98,3 +98,69 @@ func Test_parseTags(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func Test_handleCompositeType(t *testing.T) {
+	t.Run("oneOf", func(t *testing.T) {
+		p, err := newParser("example/", "example/main.go", "", false)
+		require.NoError(t, err)
+		result, err := p.handleCompositeType("./example", "example.com/example", "oneOf(string,int32)", true)
+		require.NoError(t, err)
+		s, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.Equal(t, "{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}", string(s))
+	})
+
+	t.Run("anyOf", func(t *testing.T) {
+		p, err := newParser("example/", "example/main.go", "", false)
+		require.NoError(t, err)
+		result, err := p.handleCompositeType("./example", "example.com/example", "anyOf(string,int32)", true)
+		require.NoError(t, err)
+		s, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.Equal(t, "{\"anyOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}", string(s))
+	})
+
+	t.Run("allOf", func(t *testing.T) {
+		p, err := newParser("example/", "example/main.go", "", false)
+		require.NoError(t, err)
+		result, err := p.handleCompositeType("./example", "example.com/example", "allOf(string,int32)", true)
+		require.NoError(t, err)
+		s, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.Equal(t, "{\"allOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}", string(s))
+	})
+
+	t.Run("not", func(t *testing.T) {
+		p, err := newParser("example/", "example/main.go", "", false)
+		require.NoError(t, err)
+		result, err := p.handleCompositeType("./example", "example.com/example", "not(string)", true)
+		require.NoError(t, err)
+		s, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.Equal(t, "{\"not\":{\"type\":\"string\"}}", string(s))
+	})
+
+	t.Run("handles whitespace", func(t *testing.T) {
+		p, err := newParser("example/", "example/main.go", "", false)
+		require.NoError(t, err)
+		result, err := p.handleCompositeType("./example", "example.com/example", "allOf(  string, int32 )", true)
+		require.NoError(t, err)
+		s, err := json.Marshal(result)
+		require.NoError(t, err)
+		require.Equal(t, "{\"allOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]}", string(s))
+	})
+
+	t.Run("not only accepts 1 arg", func(t *testing.T) {
+		p, err := newParser("example/", "example/main.go", "", false)
+		require.NoError(t, err)
+		_, notErr := p.handleCompositeType("./example", "example.com/example", "not(string,int32)", true)
+		require.Error(t, notErr)
+	})
+
+	t.Run("error when no args", func(t *testing.T) {
+		p, err := newParser("example/", "example/main.go", "", false)
+		require.NoError(t, err)
+		_, notErr := p.handleCompositeType("./example", "example.com/example", "oneOf()", true)
+		require.Error(t, notErr)
+	})
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -99,11 +99,11 @@ func Test_parseTags(t *testing.T) {
 	})
 }
 
-func Test_handleCompositeType(t *testing.T) {
+func Test_handleCompoundType(t *testing.T) {
 	t.Run("oneOf", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "oneOf(string,[]string)")
+		result, err := p.handleCompoundType("./example", "example.com/example", "oneOf(string,[]string)")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
@@ -113,7 +113,7 @@ func Test_handleCompositeType(t *testing.T) {
 	t.Run("anyOf", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "anyOf(string,[]string)")
+		result, err := p.handleCompoundType("./example", "example.com/example", "anyOf(string,[]string)")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
@@ -123,7 +123,7 @@ func Test_handleCompositeType(t *testing.T) {
 	t.Run("allOf", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "allOf(string,[]string)")
+		result, err := p.handleCompoundType("./example", "example.com/example", "allOf(string,[]string)")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
@@ -133,7 +133,7 @@ func Test_handleCompositeType(t *testing.T) {
 	t.Run("not", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "not(string)")
+		result, err := p.handleCompoundType("./example", "example.com/example", "not(string)")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
@@ -143,7 +143,7 @@ func Test_handleCompositeType(t *testing.T) {
 	t.Run("handles whitespace", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		result, err := p.handleCompositeType("./example", "example.com/example", "allOf(  string, []string )")
+		result, err := p.handleCompoundType("./example", "example.com/example", "allOf(  string, []string )")
 		require.NoError(t, err)
 		s, err := json.Marshal(result)
 		require.NoError(t, err)
@@ -153,14 +153,14 @@ func Test_handleCompositeType(t *testing.T) {
 	t.Run("not only accepts 1 arg", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		_, notErr := p.handleCompositeType("./example", "example.com/example", "not(string,int32)")
+		_, notErr := p.handleCompoundType("./example", "example.com/example", "not(string,int32)")
 		require.Error(t, notErr)
 	})
 
 	t.Run("error when no args", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
-		_, notErr := p.handleCompositeType("./example", "example.com/example", "oneOf()")
+		_, notErr := p.handleCompoundType("./example", "example.com/example", "oneOf()")
 		require.Error(t, notErr)
 	})
 }


### PR DESCRIPTION
Adds support for using `oneOf|anyOf|allOf|not` composite types in body param annotations, e.g.

```
// @Param foo body oneOf(string, int32) true "Foo body"
```

