### PR TITLE
Inline description refs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/iancoleman/orderedmap v0.1.0
+	github.com/jarcoal/httpmock v1.0.8
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.5
 	golang.org/x/mod v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/iancoleman/orderedmap v0.1.0 h1:2orAxZBJsvimgEBmMWfXaFlzSG2fbQil5qzP3F6cCkg=
 github.com/iancoleman/orderedmap v0.1.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
+github.com/jarcoal/httpmock v1.0.8 h1:8kI16SoO6LQKgPE7PvQuV+YuD/inwHd7fOOe2zMbo4k=
+github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=

--- a/parser.go
+++ b/parser.go
@@ -7,7 +7,6 @@ import (
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -305,7 +304,7 @@ func fetchRef(description string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/parser.go
+++ b/parser.go
@@ -7,6 +7,7 @@ import (
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -256,6 +257,13 @@ func (p *parser) CreateOASFile(path string) error {
 	}
 	defer fd.Close()
 
+	// for descriptions specified with $refs, pull that content in and embed it directly
+	// TODO may be a good idea to make this optional via clarg
+	err = p.explodeRefs()
+	if err != nil {
+		return err
+	}
+
 	output, err := json.MarshalIndent(p.OpenAPI, "", "  ")
 	if err != nil {
 		return err
@@ -263,6 +271,46 @@ func (p *parser) CreateOASFile(path string) error {
 	_, err = fd.WriteString(string(output))
 
 	return err
+}
+
+func (p *parser) explodeRefs() error {
+	if p.OpenAPI.Info.Description != nil {
+		desc, err := fetchRef(p.OpenAPI.Info.Description.Value)
+		if err != nil {
+			return err
+		}
+		p.OpenAPI.Info.Description.Value = desc
+	}
+	for i, tag := range p.OpenAPI.Tags {
+		if tag.Description == nil {
+			continue
+		}
+		desc, err := fetchRef(tag.Description.Value)
+		if err != nil {
+			return err
+		}
+		p.OpenAPI.Tags[i].Description.Value = desc
+	}
+
+	return nil
+}
+
+func fetchRef(description string) (string, error) {
+	if !strings.HasPrefix(description, "$ref:") {
+		return description, nil
+	}
+	url := description[5:]
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
 }
 
 func (p *parser) parseEntryPoint() error {


### PR DESCRIPTION
If `info.description` or `tags[].description` are refs, go ahead and grab the ref'd string before we serialize the spec.

We may want to make this a CL argument option at some point, if we want to support including them as `$ref` as they were before this change.