### PR TITLE
remove required support from json tag

### DIFF
--- a/example/example.json
+++ b/example/example.json
@@ -394,6 +394,9 @@
           },
           "Example": {
             "$ref": "#/components/schemas/DoubleAlias"
+          },
+          "Required": {
+            "type": "boolean"
           }
         }
       },

--- a/example/foo.go
+++ b/example/foo.go
@@ -35,8 +35,9 @@ type FooResponse struct {
 }
 
 type FooBody struct {
-	Name    string      `json:"name"`
-	Example DoubleAlias `'json:"doubleAlias"`
+	Name     string      `json:"name"`
+	Example  DoubleAlias `'json:"doubleAlias"`
+	Required bool        `json:"required"`
 }
 type Environment struct {
 	Name string `json:"name"`

--- a/parser.go
+++ b/parser.go
@@ -1633,8 +1633,6 @@ func parseStructTags(astField *ast.Field, structSchema *SchemaObject, fieldSchem
 				structSchema.DisabledFieldNames[name] = struct{}{}
 				fieldSchema.Deprecated = true
 				return "", true
-			} else if v == "required" {
-				isRequired = true
 			} else if v != "" && v != "required" && v != "omitempty" {
 				name = v
 			}


### PR DESCRIPTION
Any field that is required should use the annotation `required:"true"` instead of overloading it onto the JSON tag.