### PR TITLE
make all fields required that are not pointers

### DIFF
--- a/example/example.json
+++ b/example/example.json
@@ -469,10 +469,7 @@
       },
       "UnixMillis": {
         "type": "integer",
-        "format": "int64",
-        "required": [
-          "int64"
-        ]
+        "format": "int64"
       }
     },
     "securitySchemes": {

--- a/example/example.json
+++ b/example/example.json
@@ -425,7 +425,6 @@
           "doubleAlias",
           "interfaceBlah",
           "instruction",
-          "randomBool",
           "myEnum"
         ]
       },
@@ -470,7 +469,10 @@
       },
       "UnixMillis": {
         "type": "integer",
-        "format": "int64"
+        "format": "int64",
+        "required": [
+          "int64"
+        ]
       }
     },
     "securitySchemes": {

--- a/example/example.json
+++ b/example/example.json
@@ -265,7 +265,10 @@
           "name": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "name"
+        ]
       },
       "FooMergePatch": {
         "type": "object",
@@ -274,7 +277,10 @@
             "type": "integer",
             "format": "int64"
           }
-        }
+        },
+        "required": [
+          "count"
+        ]
       },
       "FooPatchOperation": {
         "type": "object",
@@ -288,7 +294,12 @@
           "value": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "op",
+          "path",
+          "value"
+        ]
       },
       "FooPatchOperationSet": {
         "type": "object",
@@ -307,10 +318,18 @@
                 "value": {
                   "type": "string"
                 }
-              }
+              },
+              "required": [
+                "op",
+                "path",
+                "value"
+              ]
             }
           }
-        }
+        },
+        "required": [
+          "operations"
+        ]
       },
       "FooResponse": {
         "type": "object",
@@ -349,7 +368,11 @@
                 "b": {
                   "type": "string"
                 }
-              }
+              },
+              "required": [
+                "a",
+                "b"
+              ]
             }
           },
           "environments": {
@@ -360,7 +383,10 @@
                 "name": {
                   "type": "string"
                 }
-              }
+              },
+              "required": [
+                "name"
+              ]
             }
           },
           "freeForm": {},
@@ -384,7 +410,24 @@
             "type": "boolean",
             "example": true
           }
-        }
+        },
+        "required": [
+          "bsonId",
+          "id",
+          "startDate",
+          "endDate",
+          "count",
+          "msg",
+          "foo",
+          "environments",
+          "freeForm",
+          "jsonMap",
+          "doubleAlias",
+          "interfaceBlah",
+          "instruction",
+          "randomBool",
+          "myEnum"
+        ]
       },
       "FooBody": {
         "type": "object",
@@ -395,7 +438,11 @@
           "Example": {
             "$ref": "#/components/schemas/DoubleAlias"
           }
-        }
+        },
+        "required": [
+          "name",
+          "Example"
+        ]
       },
       "InnerFoo": {
         "type": "object",
@@ -406,7 +453,11 @@
           "b": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "a",
+          "b"
+        ]
       },
       "Instruction": {
         "type": "object",

--- a/parser.go
+++ b/parser.go
@@ -1359,10 +1359,6 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 
 	if isGoTypeOASType(p.getTypeAsString(typeSpec.Type)) && schemaObject.Ref == "" {
 		typeAsString := p.getTypeAsString(typeSpec.Type)
-		isPtr := isTypePtr(typeSpec.Type)
-		if !isPtr {
-			schemaObject.Required = append(schemaObject.Required, typeAsString)
-		}
 		localGoType := goTypesOASTypes[typeAsString]
 		schemaObject.Type = &localGoType
 		checkFormatInt64(typeAsString, &schemaObject)
@@ -1501,16 +1497,11 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 		// normal ast parsing of the struct field is not returning that the type is a pointer. Relying on text parsing to determine.
 		isRequired := true
 		fset := token.NewFileSet()
-		var typeNameBuf bytes.Buffer
-		err := printer.Fprint(&typeNameBuf, fset, astField.Type)
-		if err != nil {
-			log.Fatalf("failed printing %s", err)
-		}
 
 		// Rely on omitempty property of tag.
 		if astField.Tag != nil {
 			var tagBuf bytes.Buffer
-			err = printer.Fprint(&tagBuf, fset, astField.Tag)
+			err := printer.Fprint(&tagBuf, fset, astField.Tag)
 			if err != nil {
 				log.Fatalf("failed printing %s", err)
 			}

--- a/parser.go
+++ b/parser.go
@@ -1552,7 +1552,6 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 			}
 		} else {
 			name := astField.Names[0].Name
-
 			fieldSchema.FieldName = name
 			_, disabled := structSchema.DisabledFieldNames[name]
 			if disabled {


### PR DESCRIPTION
This change makes all fields that are not pointers into required fields in the OpenAPI v3 spec. Fields that are pointers and required can still be manually annotated.