### PR TITLE
Allow inline refs for endpoint descriptions

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -870,12 +870,11 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 }
 
 func (p *parser) parseDescription(operation *OperationObject, description string) error {
-	sourceString := strings.TrimSpace(description[len("@Description"):])
-	desc, err := fetchRef(sourceString)
+	desc, err := fetchRef(description)
 	if err != nil {
 		return err
 	}
-	operation.Description = strings.Join([]string{operation.Description, "@Description", desc}, " ")
+	operation.Description = strings.Join([]string{operation.Description, desc}, " ")
 	return nil
 }
 

--- a/parser.go
+++ b/parser.go
@@ -839,19 +839,20 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			continue
 		}
 		attribute := strings.Fields(comment)[0]
+		value := strings.TrimSpace(comment[len(attribute):])
 		switch strings.ToLower(attribute) {
 		case "@title":
-			operation.Summary = strings.TrimSpace(comment[len(attribute):])
+			operation.Summary = value
 		case "@description":
-			operation.Description = strings.Join([]string{operation.Description, strings.TrimSpace(comment[len(attribute):])}, " ")
+			err = p.parseDescription(operation, value)
 		case "@operationid":
-			operation.OperationID = strings.TrimSpace(comment[len(attribute):])
+			operation.OperationID = value
 		case "@param":
-			err = p.parseParamComment(pkgPath, pkgName, operation, strings.TrimSpace(comment[len(attribute):]))
+			err = p.parseParamComment(pkgPath, pkgName, operation, value)
 		case "@success", "@failure":
-			err = p.parseResponseComment(pkgPath, pkgName, operation, strings.TrimSpace(comment[len(attribute):]))
+			err = p.parseResponseComment(pkgPath, pkgName, operation, value)
 		case "@resource", "@tag":
-			resource := strings.TrimSpace(comment[len(attribute):])
+			resource := value
 			if resource == "" {
 				resource = "others"
 			}
@@ -865,6 +866,16 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			return err
 		}
 	}
+	return nil
+}
+
+func (p *parser) parseDescription(operation *OperationObject, description string) error {
+	sourceString := strings.TrimSpace(description[len("@Description"):])
+	desc, err := fetchRef(sourceString)
+	if err != nil {
+		return err
+	}
+	operation.Description = strings.Join([]string{operation.Description, "@Description", desc}, " ")
 	return nil
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -275,10 +275,10 @@ func Test_descriptions(t *testing.T) {
 			Responses: map[string]*ResponseObject{},
 		}
 
-		err = p.parseDescription(operation, "@Description testing")
+		err = p.parseDescription(operation, "testing")
 		require.NoError(t, err)
 
-		require.Equal(t, " @Description testing", operation.Description)
+		require.Equal(t, " testing", operation.Description)
 	})
 
 	t.Run("Description inline when a ref", func(t *testing.T) {
@@ -294,9 +294,9 @@ func Test_descriptions(t *testing.T) {
 			Responses: map[string]*ResponseObject{},
 		}
 
-		err = p.parseDescription(operation, "@Description $ref:https://example.com")
+		err = p.parseDescription(operation, "$ref:https://example.com")
 		require.NoError(t, err)
 
-		require.Equal(t, " @Description The quick brown fox jumped over the lazy dog", operation.Description)
+		require.Equal(t, " The quick brown fox jumped over the lazy dog", operation.Description)
 	})
 }


### PR DESCRIPTION
Be able to specify ref instead of manually inlining content
```
@Description $ref:https://...
```
