### PR TITLE
Support smaller example request bodies

### DIFF
--- a/oas.go
+++ b/oas.go
@@ -150,8 +150,8 @@ type RequestBodyObject struct {
 }
 
 type MediaTypeObject struct {
-	Schema SchemaObject `json:"schema,omitempty"`
-	// Example string       `json:"example,omitempty"`
+	Schema  SchemaObject `json:"schema,omitempty"`
+	Example interface{}  `json:"example,omitempty"`
 
 	// Examples
 	// Encoding

--- a/parser.go
+++ b/parser.go
@@ -987,15 +987,23 @@ func (p *parser) parseParamComment(pkgPath, pkgName string, operation *Operation
 	}
 	// parse example
 	if len(matches) > 6 && matches[6] != "" {
-		exampleJsonBody := map[string]interface{}{}
-		err := json.Unmarshal([]byte(strings.Replace(matches[6], "\\\"", "\"", -1)), &exampleJsonBody)
+		exampleRequestBody, err := parseRequestBodyExample(matches[6])
 		if err != nil {
 			return err
 		}
-		operation.RequestBody.Content[ContentTypeJson].Example = exampleJsonBody
+		operation.RequestBody.Content[ContentTypeJson].Example = exampleRequestBody
 	}
 
 	return nil
+}
+
+func parseRequestBodyExample(example string) (interface{}, error) {
+	exampleRequestBody := map[string]interface{}{}
+	err := json.Unmarshal([]byte(strings.Replace(example, "\\\"", "\"", -1)), &exampleRequestBody)
+	if err != nil {
+		return nil, err
+	}
+	return exampleRequestBody, nil
 }
 
 func (p *parser) parseBodyType(pkgPath, pkgName, typeName string) (*SchemaObject, error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -300,3 +300,17 @@ func Test_descriptions(t *testing.T) {
 		require.Equal(t, " The quick brown fox jumped over the lazy dog", operation.Description)
 	})
 }
+
+func Test_parseRequestBodyExample(t *testing.T) {
+	t.Run("Parses example request body", func(t *testing.T) {
+		exampleRequestBody, err := parseRequestBodyExample("{\\\"name\\\":\\\"Bilbo\\\"}")
+		require.NoError(t, err)
+
+		require.Equal(t, map[string]interface{}(map[string]interface{}{"name": "Bilbo"}), exampleRequestBody)
+	})
+
+	t.Run("Errors if example is invalid", func(t *testing.T) {
+		_, err := parseRequestBodyExample("{name:\\\"Smaug\\\"}")
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Adds support for request body examples, e.g.

```
// @Param  project  body  reps2.ProjectPost  true  "New project data"  "{\"name\":\"My Project\",\"key\":\"my-project\"}"
```

This will embed the example in the request body spec

![image](https://user-images.githubusercontent.com/1778991/127663512-8a1ca9af-37e8-4804-a04f-f75de72c13b0.png)
