### PR TITLE
Parse Nested structs: ch102258

### DIFF
--- a/example/example.json
+++ b/example/example.json
@@ -256,8 +256,7 @@
         "type": "string"
       },
       "DoubleAlias": {
-        "type": "object",
-        "additionalProperties": {}
+        "$ref": "#/components/schemas/JsonMap"
       },
       "Environment": {
         "type": "object",
@@ -294,21 +293,10 @@
         "type": "object",
         "properties": {
           "operations": {
-            "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "op": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
-            }
+              "$ref": "#/components/schemas/FooPatchOperation"
+            },
+            "type": "array"
           }
         }
       },
@@ -339,28 +327,15 @@
             "type": "string"
           },
           "foo": {
-            "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "a": {
-                  "type": "string"
-                },
-                "b": {
-                  "type": "string"
-                }
-              }
-            }
+              "$ref": "#/components/schemas/InnerFoo"
+            },
+            "type": "array"
           },
           "environments": {
             "type": "object",
             "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/components/schemas/Environment"
             }
           },
           "freeForm": {},

--- a/parser.go
+++ b/parser.go
@@ -1564,7 +1564,7 @@ func (p *parser) parseAstField(pkgPath, pkgName string, structSchema *SchemaObje
 				} else {
 					if foundSchema.Properties != nil {
 						if len(foundSchema.Required) > 0 {
-							hoistRequiredProps(foundSchema, fieldSchema, structSchema)
+							assignRequiredPropsToParent(foundSchema, fieldSchema, structSchema)
 						} else {
 							fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaObjectID)
 						}
@@ -1853,7 +1853,7 @@ func setNestedFieldSchemaProps(valuePrefix, typeAsString string, fieldSchema, st
 	}
 }
 
-func hoistRequiredProps(foundSchema, fieldSchema, structSchema *SchemaObject) {
+func assignRequiredPropsToParent(foundSchema, fieldSchema, structSchema *SchemaObject) {
 	for _, key := range foundSchema.Properties.Keys() {
 		parsedSchemaProp, _ := foundSchema.Properties.Get(key)
 		parsedSchema := parsedSchemaProp.(*SchemaObject)

--- a/parser.go
+++ b/parser.go
@@ -1559,7 +1559,7 @@ func (p *parser) parseAstField(pkgPath, pkgName string, structSchema *SchemaObje
 			fieldSchema.ID = fieldSchemaObjectID
 			foundSchema, ok := p.KnownIDSchema[fieldSchemaObjectID]
 			if ok {
-				if astField.Tag != nil && !isBasicGoType(foundSchema.Format) && foundSchema.Properties == nil && !reflect.DeepEqual(foundSchema, SchemaObject{}) { // inlined structs do not support tagging.
+				if astField.Tag != nil && !isBasicGoType(foundSchema.Format) && foundSchema.Properties == nil { // inlined structs do not support tagging.
 					fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaObjectID)
 				} else {
 					if foundSchema.Properties != nil {

--- a/parser.go
+++ b/parser.go
@@ -1568,13 +1568,17 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 				fieldSchema.ID = fieldSchemaSchemeaObjectID
 				foundSchema, ok := p.KnownIDSchema[fieldSchemaSchemeaObjectID]
 				if ok {
-					if astField.Tag != nil { // inlined structs do not support tagging.
-						fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
+					if astField.Tag != nil && foundSchema.Properties == nil { // inlined structs do not support tagging.
+						structSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 					} else {
 						if foundSchema.Properties != nil {
-							structSchema.Properties = foundSchema.Properties
-							for _, required := range foundSchema.Required {
-								structSchema.Required = append(structSchema.Required, required)
+							if len(foundSchema.Required) > 0 {
+								structSchema.Properties = foundSchema.Properties
+								for _, required := range foundSchema.Required {
+									structSchema.Required = append(structSchema.Required, required)
+								}
+							} else {
+								fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 							}
 						}
 					}

--- a/parser.go
+++ b/parser.go
@@ -1568,8 +1568,8 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 				fieldSchema.ID = fieldSchemaSchemeaObjectID
 				foundSchema, ok := p.KnownIDSchema[fieldSchemaSchemeaObjectID]
 				if ok {
-					if astField.Tag != nil && foundSchema.Format != "" && !isBasicGoType(foundSchema.Format) && foundSchema.Items == nil { // inlined structs do not support tagging.
-						structSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
+					if astField.Tag != nil && !isBasicGoType(foundSchema.Format) && foundSchema.Properties == nil && !reflect.DeepEqual(foundSchema, SchemaObject{}) { // inlined structs do not support tagging.
+						fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 					} else {
 						if foundSchema.Properties != nil {
 							if len(foundSchema.Required) > 0 {
@@ -1600,6 +1600,8 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 					}
 					fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 				}
+
+				fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 			}
 		} else if isGoTypeOASType(typeAsString) {
 			localGoType := goTypesOASTypes[typeAsString]

--- a/parser.go
+++ b/parser.go
@@ -1493,10 +1493,11 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 					if _, ok := p.KnownIDSchema[valueType]; ok {
 						if strings.HasPrefix(splitType[0], "map") {
 							fieldSchema.Type = &objectType
+							fieldSchema.AdditionalProperties = &SchemaObject{Ref: addSchemaRefLinkPrefix(p.getTypeAsString(valueType))}
 						} else {
 							fieldSchema.Type = &arrayType
+							fieldSchema.Items = &SchemaObject{Ref: addSchemaRefLinkPrefix(p.getTypeAsString(valueType))}
 						}
-						fieldSchema.Items = &SchemaObject{Ref: addSchemaRefLinkPrefix(p.getTypeAsString(valueType))}
 					} else {
 						fieldSchemaSchemeaObjectID, err := p.registerType(pkgPath, pkgName, typeAsString)
 						fieldSchema, err = p.parseSchemaObject(pkgPath, pkgName, typeAsString, true)

--- a/parser.go
+++ b/parser.go
@@ -1589,6 +1589,9 @@ func (p *parser) parseAstField(pkgPath, pkgName string, structSchema *SchemaObje
 				propertySchema, _ := fieldSchema.Properties.Get(propertyName)
 				structSchema.Properties.Set(propertyName, propertySchema)
 			}
+			for _, required := range fieldSchema.Required {
+				structSchema.Required = append(structSchema.Required, required)
+			}
 		} else if len(fieldSchema.Ref) != 0 && len(fieldSchema.ID) != 0 {
 			refSchema, ok := p.KnownIDSchema[fieldSchema.ID]
 			if ok {
@@ -1606,10 +1609,6 @@ func (p *parser) parseAstField(pkgPath, pkgName string, structSchema *SchemaObje
 					if exist {
 						return
 					}
-					for _, required := range fieldSchema.Required {
-						structSchema.Required = append(structSchema.Required, required)
-					}
-
 					structSchema.Properties.Set(propertyName, refPropertySchema)
 				}
 			}

--- a/parser.go
+++ b/parser.go
@@ -1518,29 +1518,19 @@ func (p *parser) parseAstField(pkgPath, pkgName string, structSchema *SchemaObje
 	isInterface := strings.HasPrefix(typeAsString, "interface{}")
 	if isSliceOrMap || isInterface || typeAsString == "time.Time" {
 		splitType := strings.Split(typeAsString, "]")
-		if len(splitType) > 1 {
-			valueType := splitType[1]
-			if !isBasicGoType(valueType) {
-				if _, ok := p.KnownIDSchema[valueType]; ok {
-					nestedType := p.getTypeAsString(splitType[1])
-					setNestedFieldSchemaProps(splitType[0], nestedType, fieldSchema, structSchema)
-				} else {
-					fieldSchemaObjectID, err := p.registerType(pkgPath, pkgName, typeAsString)
-					fieldSchema, err = p.parseSchemaObject(pkgPath, pkgName, typeAsString, true)
-					if err != nil {
-						p.debug(err)
-						return
-					}
-					if fieldSchemaObjectID != "" {
-						structSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaObjectID)
-					}
-				}
+		if len(splitType) > 1 && !isBasicGoType(splitType[1]) {
+			if _, ok := p.KnownIDSchema[splitType[1]]; ok {
+				nestedType := p.getTypeAsString(splitType[1])
+				setNestedFieldSchemaProps(splitType[0], nestedType, fieldSchema, structSchema)
 			} else {
-				var err error
+				fieldSchemaObjectID, err := p.registerType(pkgPath, pkgName, typeAsString)
 				fieldSchema, err = p.parseSchemaObject(pkgPath, pkgName, typeAsString, true)
 				if err != nil {
 					p.debug(err)
 					return
+				}
+				if fieldSchemaObjectID != "" {
+					structSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaObjectID)
 				}
 			}
 		} else {

--- a/parser.go
+++ b/parser.go
@@ -1564,18 +1564,7 @@ func (p *parser) parseAstField(pkgPath, pkgName string, structSchema *SchemaObje
 				} else {
 					if foundSchema.Properties != nil {
 						if len(foundSchema.Required) > 0 {
-							for _, key := range foundSchema.Properties.Keys() {
-								parsedSchemaProp, _ := foundSchema.Properties.Get(key)
-								parsedSchema := parsedSchemaProp.(*SchemaObject)
-								if parsedSchema.Items != nil {
-									if parsedSchema.Items.Ref != "" {
-										fieldSchema.Ref = parsedSchema.Items.Ref
-									}
-								}
-							}
-							for _, required := range foundSchema.Required {
-								structSchema.Required = append(structSchema.Required, required)
-							}
+							hoistRequiredProps(foundSchema, fieldSchema, structSchema)
 						} else {
 							fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaObjectID)
 						}
@@ -1861,5 +1850,20 @@ func setNestedFieldSchemaProps(valuePrefix, typeAsString string, fieldSchema, st
 	} else {
 		fieldSchema.Type = &arrayType
 		fieldSchema.Items = &SchemaObject{Ref: addSchemaRefLinkPrefix(typeAsString)}
+	}
+}
+
+func hoistRequiredProps(foundSchema, fieldSchema, structSchema *SchemaObject) {
+	for _, key := range foundSchema.Properties.Keys() {
+		parsedSchemaProp, _ := foundSchema.Properties.Get(key)
+		parsedSchema := parsedSchemaProp.(*SchemaObject)
+		if parsedSchema.Items != nil {
+			if parsedSchema.Items.Ref != "" {
+				fieldSchema.Ref = parsedSchema.Items.Ref
+			}
+		}
+	}
+	for _, required := range foundSchema.Required {
+		structSchema.Required = append(structSchema.Required, required)
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -1547,20 +1547,6 @@ func (p *parser) parseAstField(pkgPath, pkgName string, structSchema *SchemaObje
 			p.debug("parseSchemaPropertiesFromStructFields err:", err)
 		} else {
 			fieldSchema.ID = fieldSchemaObjectID
-			foundSchema, ok := p.KnownIDSchema[fieldSchemaObjectID]
-			if ok {
-				if astField.Tag != nil && !isBasicGoType(foundSchema.Format) && foundSchema.Properties == nil { // inlined structs do not support tagging.
-					fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaObjectID)
-				}
-			} else {
-				fieldSchema, err = p.parseSchemaObject(pkgPath, pkgName, typeAsString, true)
-				if err != nil {
-					p.debug(err)
-					return
-				}
-				fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaObjectID)
-			}
-
 			fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaObjectID)
 		}
 	} else if isGoTypeOASType(typeAsString) {

--- a/parser.go
+++ b/parser.go
@@ -1368,9 +1368,6 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 			return nil, err
 		}
 		schemaObject.Ref = addSchemaRefLinkPrefix(newSchema.ID)
-		// schemaObject.Type = newSchema.Type
-		// schemaObject.Properties = newSchema.Properties
-		// schemaObject.AdditionalProperties = newSchema.AdditionalProperties
 	} else if astStructType, ok := typeSpec.Type.(*ast.StructType); ok {
 		schemaObject.Type = &objectType
 		if astStructType.Fields != nil {
@@ -1527,7 +1524,6 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 					return
 				}
 			}
-
 		} else if !isBasicGoType(typeAsString) {
 			fieldSchemaSchemeaObjectID, err := p.registerType(pkgPath, pkgName, typeAsString)
 			if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -1491,14 +1491,15 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 		if isSliceOrMap || isInterface || typeAsString == "time.Time" {
 			splitType := strings.Split(typeAsString, "]")
 			if len(splitType) > 1 {
-				if !isBasicGoType(splitType[1]) {
-					if _, ok := p.KnownIDSchema[splitType[1]]; ok {
-						if strings.Contains(splitType[0], "map") {
+				valueType := splitType[1]
+				if !isBasicGoType(valueType) {
+					if _, ok := p.KnownIDSchema[valueType]; ok {
+						if strings.HasPrefix(splitType[0], "map") {
 							fieldSchema.Type = &objectType
 						} else {
 							fieldSchema.Type = &arrayType
 						}
-						fieldSchema.Items = &SchemaObject{Ref: addSchemaRefLinkPrefix(p.getTypeAsString(splitType[1]))}
+						fieldSchema.Items = &SchemaObject{Ref: addSchemaRefLinkPrefix(p.getTypeAsString(valueType))}
 					} else {
 						fieldSchemaSchemeaObjectID, err := p.registerType(pkgPath, pkgName, typeAsString)
 						fieldSchema, err = p.parseSchemaObject(pkgPath, pkgName, typeAsString, true)

--- a/parser.go
+++ b/parser.go
@@ -1538,9 +1538,11 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 					if astField.Tag != nil { // inlined structs do not support tagging.
 						fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 					} else {
-						structSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
-						for _, required := range foundSchema.Required {
-							structSchema.Required = append(structSchema.Required, required)
+						if foundSchema.Properties != nil {
+							structSchema.Properties = foundSchema.Properties
+							for _, required := range foundSchema.Required {
+								structSchema.Required = append(structSchema.Required, required)
+							}
 						}
 					}
 				} else {

--- a/parser.go
+++ b/parser.go
@@ -1568,7 +1568,7 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 				fieldSchema.ID = fieldSchemaSchemeaObjectID
 				foundSchema, ok := p.KnownIDSchema[fieldSchemaSchemeaObjectID]
 				if ok {
-					if astField.Tag != nil && foundSchema.Format != "" && !isBasicGoType(foundSchema.Format) { // inlined structs do not support tagging.
+					if astField.Tag != nil && foundSchema.Format != "" && !isBasicGoType(foundSchema.Format) && foundSchema.Items == nil { // inlined structs do not support tagging.
 						structSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 					} else {
 						if foundSchema.Properties != nil {
@@ -1581,7 +1581,6 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 											fieldSchema.Ref = parsedSchema.Items.Ref
 										}
 									}
-
 								}
 								for _, required := range foundSchema.Required {
 									structSchema.Required = append(structSchema.Required, required)

--- a/parser.go
+++ b/parser.go
@@ -1507,7 +1507,7 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 							return
 						}
 						if fieldSchemaSchemeaObjectID != "" {
-							fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
+							structSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 						}
 					}
 				} else {
@@ -1533,16 +1533,22 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 				p.debug("parseSchemaPropertiesFromStructFields err:", err)
 			} else {
 				fieldSchema.ID = fieldSchemaSchemeaObjectID
-				_, ok := p.KnownIDSchema[fieldSchemaSchemeaObjectID]
+				foundSchema, ok := p.KnownIDSchema[fieldSchemaSchemeaObjectID]
 				if ok {
-					fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
+					if astField.Tag != nil { // inlined structs do not support tagging.
+						fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
+					} else {
+						structSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
+						for _, required := range foundSchema.Required {
+							structSchema.Required = append(structSchema.Required, required)
+						}
+					}
 				} else {
 					fieldSchema, err = p.parseSchemaObject(pkgPath, pkgName, typeAsString, true)
 					if err != nil {
 						p.debug(err)
 						return
 					}
-					fmt.Println(fieldSchemaSchemeaObjectID)
 					fieldSchema.Ref = addSchemaRefLinkPrefix(fieldSchemaSchemeaObjectID)
 				}
 			}

--- a/parser.go
+++ b/parser.go
@@ -1490,19 +1490,16 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 		isInterface := strings.HasPrefix(typeAsString, "interface{}")
 		if isSliceOrMap || isInterface || typeAsString == "time.Time" {
 			splitType := strings.Split(typeAsString, "]")
-			fmt.Println(fmt.Sprintf("First: %s", splitType))
-
 			if len(splitType) > 1 {
-				fmt.Println(splitType)
 				if !isBasicGoType(splitType[1]) {
-					fmt.Println("Length longer")
-					fmt.Println(splitType[1])
 					if _, ok := p.KnownIDSchema[splitType[1]]; ok {
-						fmt.Println(fmt.Sprintf("Known: %s", p.getTypeAsString(splitType[1])))
-						fieldSchema.Type = &arrayType
-						fieldSchema.Ref = addSchemaRefLinkPrefix(p.getTypeAsString(splitType[1]))
+						if strings.Contains(splitType[0], "map") {
+							fieldSchema.Type = &objectType
+						} else {
+							fieldSchema.Type = &arrayType
+						}
+						fieldSchema.Items = &SchemaObject{Ref: addSchemaRefLinkPrefix(p.getTypeAsString(splitType[1]))}
 					} else {
-						fmt.Println(fmt.Sprintf("In else: %s", splitType))
 						fieldSchemaSchemeaObjectID, err := p.registerType(pkgPath, pkgName, typeAsString)
 						fieldSchema, err = p.parseSchemaObject(pkgPath, pkgName, typeAsString, true)
 						if err != nil {
@@ -1514,7 +1511,6 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 						}
 					}
 				} else {
-					fmt.Println(fmt.Sprintf("In other else: %s", splitType))
 					var err error
 					fieldSchema, err = p.parseSchemaObject(pkgPath, pkgName, typeAsString, true)
 					if err != nil {
@@ -1523,7 +1519,6 @@ func (p *parser) parseSchemaPropertiesFromStructFields(pkgPath, pkgName string, 
 					}
 				}
 			} else {
-				fmt.Println(fmt.Sprintf("here: %s", typeAsString))
 				var err error
 				fieldSchema, err = p.parseSchemaObject(pkgPath, pkgName, typeAsString, true)
 				if err != nil {


### PR DESCRIPTION
Nested structs like below were getting rendered out as `map[string][]map[string]interface{}`
```
type ExampleRep struct {
	Example map[string][]OtherRep `json:"example" required:"true"`
}
```

With this PR, they are now getting properly rendered as `map[string][]OtherRep`

Also existing schemas were not getting passed in as `$ref`. There was a fix for that but the API clients were still not correctly generating `required` fields. 

Now we are looping over the existing schemas in those instances to pass their `properties` and `required` to the parent struct so the clients correctly generate.

I'm not as happy with the nested conditionals but I don't see another way to rework it at this time. Open to any feedback on making it cleaner to read.
