### PR TITLE
Error out if the tag in the entry point annotation does not match any tags in the main list of tags

### DIFF
--- a/example/example.json
+++ b/example/example.json
@@ -469,6 +469,12 @@
     {
       "name": "Bar",
       "description": "Baz"
+    },
+    {
+      "name": "Vfoo"
+    },
+    {
+      "name": "Foo With Spaces"
     }
   ]
 }

--- a/example/main.go
+++ b/example/main.go
@@ -14,6 +14,8 @@ package main
 // @PackageAlias "example" ""
 // @Tags "Foo"
 // @Tags "Bar" "Baz"
+// @Tags "Vfoo"
+// @Tags "Foo With Spaces"
 
 func main() {
 

--- a/parser.go
+++ b/parser.go
@@ -840,6 +840,11 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 		return nil
 	}
 	var err error
+	var tagList []string
+	for _, tag := range p.OpenAPI.Tags {
+		tagList = append(tagList, tag.Name)
+	}
+
 	for _, astComment := range astComments {
 		comment := strings.TrimSpace(strings.TrimLeft(astComment.Text, "/"))
 		if len(comment) == 0 {
@@ -864,7 +869,10 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			if resource == "" {
 				resource = "others"
 			}
-			if !isInStringList(operation.Tags, resource) {
+
+			if !isInStringList(tagList, resource) {
+				err = fmt.Errorf("Could not find tag \"%s\" in the main list of tags", resource)
+			} else if !isInStringList(operation.Tags, resource) {
 				operation.Tags = append(operation.Tags, resource)
 			}
 		case "@route", "@router":

--- a/parser_test.go
+++ b/parser_test.go
@@ -340,19 +340,19 @@ func Test_parseOperationTags(t *testing.T) {
 		p.OpenAPI.Tags = append(p.OpenAPI.Tags, TagDefinition{Name: "foo", Description: &ReffableString{Value: "bar"}})
 
 		var comment []*ast.Comment
-		comment = append(comment, &ast.Comment{Slash: 0, Text: "// @tag foo"})
+		comment = append(comment, &ast.Comment{Slash: 0, Text: "// @Tag foo"})
 		err = p.parseOperation(p.ModulePath, "", comment)
 		require.NoError(t, err)
 	})
 
-	t.Run("Parses operation tags", func(t *testing.T) {
+	t.Run("Errors when tag in operation is not in list of tags", func(t *testing.T) {
 		p, err := newParser("example/", "example/main.go", "", false)
 		require.NoError(t, err)
 
 		p.OpenAPI.Tags = append(p.OpenAPI.Tags, TagDefinition{Name: "foo", Description: &ReffableString{Value: "bar"}})
 
 		var comment []*ast.Comment
-		comment = append(comment, &ast.Comment{Slash: 0, Text: "// @tag Foo"})
+		comment = append(comment, &ast.Comment{Slash: 0, Text: "// @Tag Foo"})
 		err = p.parseOperation(p.ModulePath, "", comment)
 		require.Error(t, err)
 	})

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"go/ast"
 	"io/ioutil"
 	"testing"
 
@@ -327,6 +328,32 @@ func Test_parseRequestBodyExample(t *testing.T) {
 
 	t.Run("Errors if example is invalid", func(t *testing.T) {
 		_, err := parseRequestBodyExample("{name:\\\"Smaug\\\"}")
+		require.Error(t, err)
+	})
+}
+
+func Test_parseOperationTags(t *testing.T) {
+	t.Run("Parses operation tags", func(t *testing.T) {
+		p, err := newParser("example/", "example/main.go", "", false)
+		require.NoError(t, err)
+
+		p.OpenAPI.Tags = append(p.OpenAPI.Tags, TagDefinition{Name: "foo", Description: &ReffableString{Value: "bar"}})
+
+		var comment []*ast.Comment
+		comment = append(comment, &ast.Comment{Slash: 0, Text: "// @tag foo"})
+		err = p.parseOperation(p.ModulePath, "", comment)
+		require.NoError(t, err)
+	})
+
+	t.Run("Parses operation tags", func(t *testing.T) {
+		p, err := newParser("example/", "example/main.go", "", false)
+		require.NoError(t, err)
+
+		p.OpenAPI.Tags = append(p.OpenAPI.Tags, TagDefinition{Name: "foo", Description: &ReffableString{Value: "bar"}})
+
+		var comment []*ast.Comment
+		comment = append(comment, &ast.Comment{Slash: 0, Text: "// @tag Foo"})
+		err = p.parseOperation(p.ModulePath, "", comment)
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
We've hit a few issues in the past with tags ending up at the bottom of the list in the docs because they don't match one that was listed (either forgotten or due to casing mismatch), so we should consider this an error.