### PR TITLE
add new struct field to override returned struct value

### DIFF
--- a/example/example-show-hidden.json
+++ b/example/example-show-hidden.json
@@ -446,6 +446,9 @@
               "value1",
               "value2"
             ]
+          },
+          "changeReturn": {
+            "$ref": "#/components/schemas/Instruction"
           }
         }
       },

--- a/example/example.json
+++ b/example/example.json
@@ -428,6 +428,9 @@
               "value1",
               "value2"
             ]
+          },
+          "changeReturn": {
+            "$ref": "#/components/schemas/Instruction"
           }
         }
       },

--- a/example/foo.go
+++ b/example/foo.go
@@ -32,6 +32,7 @@ type FooResponse struct {
 	BsonPtr       *BsonID                `json:"bsonPtr,omitempty" example:"blah blah blah"`
 	RandomBool    bool                   `json:"randomBool,omitempty" example:"true"`
 	MyEnum        string                 `json:"myEnum" goas:"enum=value1 value2"`
+	ChangeReturn  string                 `json:"changeReturn" overrideApiSchemaType:"Instruction"`
 }
 
 type FooBody struct {
@@ -43,7 +44,6 @@ type FooBody struct {
 type Environment struct {
 	Name string `json:"name"`
 }
-
 type FooPatchOperation struct {
 	op    string
 	path  string

--- a/parser.go
+++ b/parser.go
@@ -1746,7 +1746,8 @@ func (p *parser) getTypeAsString(fieldType interface{}) string {
 func parseOverrideStructTag(astField *ast.Field) (renderedStructName string) {
 	if astField.Tag != nil {
 		astFieldTag := reflect.StructTag(strings.Trim(astField.Tag.Value, "`"))
-		if renderedStructName := astFieldTag.Get("renderedStruct"); renderedStructName != "" {
+		fmt.Println(astFieldTag)
+		if renderedStructName := astFieldTag.Get("overrideApiSchemaType"); renderedStructName != "" {
 			return renderedStructName
 		}
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"go/ast"
+	"go/token"
 	"io/ioutil"
 	"testing"
 
@@ -430,5 +431,22 @@ func Test_validateSchemaNames(t *testing.T) {
 		require.Len(t, conflicts, 1)
 		require.Contains(t, conflicts[0], "pkg/foo/bar#BarRecord")
 		require.Contains(t, conflicts[0], "pkg/baz/qux#QuxRecord")
+	})
+}
+
+func Test_parseOverrideStructTag(t *testing.T) {
+	t.Run("found tag", func(t *testing.T) {
+		ast := &ast.Field{
+			Doc:   nil,
+			Names: nil,
+			Type:  nil,
+			Tag: &ast.BasicLit{
+				ValuePos: 0,
+				Kind:     token.STRING,
+				Value:    `overrideApiSchemaType:"Test"`},
+		}
+		result := parseOverrideStructTag(ast)
+
+		require.Equal(t, "Test", result)
 	})
 }


### PR DESCRIPTION
Add a new struct ~`renderedStruct ` (open to renaming, also thinking `overrideReturnedStructType`)~ `overrideApiSchemaType` that allows you to add a struct field tag to specify exactly what value you want to use as returned struct type.

An example would be:
```
type ExampleStruct {
    Name    *[]MyStruct    `json:"myStruct" description:"A struct" overrideApiSchemaType:"[]UsedStruct"`
}
```