### PR TITLE
add ability to pass in a specific path to use as starting point

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ var flags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "file-ref-path",
-		Value: "",
+		Value: ".",
 		Usage: "path to start looking for file refs",
 	},
 	cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -26,6 +26,11 @@ var flags = []cli.Flag{
 		Usage: "goas only search handleFunc comments under the path",
 	},
 	cli.StringFlag{
+		Name:  "file-ref-path",
+		Value: "",
+		Usage: "path to start looking for file refs",
+	},
+	cli.StringFlag{
 		Name:  "output",
 		Value: "oas.json",
 		Usage: "output file",
@@ -45,7 +50,7 @@ var flags = []cli.Flag{
 }
 
 func action(c *cli.Context) error {
-	p, err := newParser(c.GlobalString("module-path"), c.GlobalString("main-file-path"), c.GlobalString("handler-path"), c.GlobalBool("debug"), c.GlobalBool("omit-packages"), c.GlobalBool("show-hidden"))
+	p, err := newParser(c.GlobalString("module-path"), c.GlobalString("main-file-path"), c.GlobalString("handler-path"), c.GlobalString("file-ref-path"), c.GlobalBool("debug"), c.GlobalBool("omit-packages"), c.GlobalBool("show-hidden"))
 	if err != nil {
 		return err
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func setupParser() (*parser, error) {
-	return newParser("example/", "example/main.go", "", false, false, false)
+	return newParser("example/", "example/main.go", "", "", false, false, false)
 }
 func TestExample(t *testing.T) {
 	p, err := setupParser()
@@ -29,7 +29,7 @@ func TestExample(t *testing.T) {
 }
 
 func TestShowHiddenExample(t *testing.T) {
-	p, err := newParser("example/", "example/main.go", "", false, false, true)
+	p, err := newParser("example/", "example/main.go", "", "", false, false, true)
 	require.NoError(t, err)
 
 	err = p.parse()
@@ -284,7 +284,7 @@ func Test_explodeRefs(t *testing.T) {
 
 func Test_fetchRef(t *testing.T) {
 	t.Run("fetches local file ref", func(t *testing.T) {
-		desc, err := fetchRef("$ref:file://example/example.md")
+		desc, err := fetchRef(".", "$ref:file://example/example.md")
 		require.NoError(t, err)
 
 		require.Equal(t, "Example description", desc)
@@ -373,7 +373,7 @@ func Test_genSchemaObjectID(t *testing.T) {
 		require.Equal(t, "test.sample.sample", string(result))
 	})
 	t.Run("omit package name", func(t *testing.T) {
-		p, err := newParser("example/", "example/main.go", "", false, true, false)
+		p, err := newParser("example/", "example/main.go", "", "", false, true, false)
 		require.NoError(t, err)
 
 		result := p.genSchemaObjectID("test.sample", "sample")


### PR DESCRIPTION
This allows local use of debugger to run `goas` by passing in a starting directory to look for description references.