### PR TITLE
moonshots xvii: extend goas for cli

### DIFF
--- a/oas.go
+++ b/oas.go
@@ -43,7 +43,7 @@ type InfoObject struct {
 	Contact        *ContactObject             `json:"contact,omitempty"`
 	License        *LicenseObject             `json:"license,omitempty"`
 	Version        string                     `json:"version"`
-	CliGroups      map[string]CliConfigObject `json:"x-cli-groups,omitempty`
+	CliGroups      map[string]CliConfigObject `json:"x-cli-groups,omitempty"`
 }
 
 // Wrapper for a string that may be of the form `$ref:foo`

--- a/oas.go
+++ b/oas.go
@@ -37,12 +37,13 @@ type ServerObject struct {
 }
 
 type InfoObject struct {
-	Title          string          `json:"title"`
-	Description    *ReffableString `json:"description,omitempty"`
-	TermsOfService string          `json:"termsOfService,omitempty"`
-	Contact        *ContactObject  `json:"contact,omitempty"`
-	License        *LicenseObject  `json:"license,omitempty"`
-	Version        string          `json:"version"`
+	Title          string                     `json:"title"`
+	Description    *ReffableString            `json:"description,omitempty"`
+	TermsOfService string                     `json:"termsOfService,omitempty"`
+	Contact        *ContactObject             `json:"contact,omitempty"`
+	License        *LicenseObject             `json:"license,omitempty"`
+	Version        string                     `json:"version"`
+	CliGroups      map[string]CliConfigObject `json:"x-cli-groups,omitempty`
 }
 
 // Wrapper for a string that may be of the form `$ref:foo`
@@ -105,6 +106,11 @@ type OperationObject struct {
 	Parameters  []ParameterObject  `json:"parameters,omitempty"`
 	RequestBody *RequestBodyObject `json:"requestBody,omitempty"`
 	OperationID string             `json:"operationId,omitempty"`
+	// CLI Generation parameters
+	CliIgnore  bool     `json:"x-cli-ignore,omitempty`
+	CliGroup   string   `json:"x-cli-group,omitempty"`
+	CliAliases []string `json:"x-cli-aliases,omitempty"`
+
 	// Tags
 	// ExternalDocs
 	// OperationID
@@ -296,4 +302,8 @@ type SecuritySchemeOauthFlowObject struct {
 type TagDefinition struct {
 	Name        string          `json:"name"`
 	Description *ReffableString `json:"description,omitempty"`
+}
+
+type CliConfigObject struct {
+	Aliases []string `json:"aliases,omitempty"`
 }

--- a/oas.go
+++ b/oas.go
@@ -107,9 +107,9 @@ type OperationObject struct {
 	RequestBody *RequestBodyObject `json:"requestBody,omitempty"`
 	OperationID string             `json:"operationId,omitempty"`
 	// CLI Generation parameters
-	CliIgnore  bool     `json:"x-cli-ignore,omitempty`
-	CliGroup   string   `json:"x-cli-group,omitempty"`
-	CliAliases []string `json:"x-cli-aliases,omitempty"`
+	CliIgnore           bool     `json:"x-cli-ignore,omitempty`
+	CliGroup            string   `json:"x-cli-group,omitempty"`
+	CliOperationAliases []string `json:"x-cli-aliases,omitempty"`
 
 	// Tags
 	// ExternalDocs

--- a/parser.go
+++ b/parser.go
@@ -962,6 +962,12 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			}
 		case "@route", "@router":
 			err = p.parseRouteComment(operation, comment)
+		case "@cligroup":
+			operation.CliGroup = value
+		case "@clialiases":
+			p.parseCliOperationAliases(operation, value)
+		case "@cliignore":
+			operation.CliIgnore = true
 		}
 		if err != nil {
 			return err
@@ -1214,6 +1220,13 @@ func (p *parser) parseResponseComment(pkgPath, pkgName string, operation *Operat
 	operation.Responses[status] = responseObject
 
 	return nil
+}
+
+func (p *parser) parseCliOperationAliases(operation *OperationObject, value string) {
+	aliases := strings.Split(value, ",")
+	for _, alias := range aliases {
+		operation.CliOperationAliases = append(operation.CliOperationAliases, strings.TrimSpace(alias))
+	}
 }
 
 func (p *parser) routeAndMethodExist(route string, method string) bool {


### PR DESCRIPTION
Adds a `CliGroups` config object containing `Aliases` to the `InfoObject` and `CliIgnore`, `CliOperationAliases` and `CliGroups` to the `OperationObject` & updates parsing to handle them.

TODO: verify it works, write tests & update existing tests