### PR TITLE
add CLI extension fields to spec parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 glide.lock
 .idea/
 goas
+.vscode/

--- a/example/example-show-hidden.json
+++ b/example/example-show-hidden.json
@@ -41,7 +41,9 @@
           }
         },
         "summary": "Get all birds",
+        "description": "DefaultDescription",
         "operationId": "getBirds",
+        "x-cli-description": "DefaultDescription",
         "x-cli-group": "birds",
         "x-cli-name": "list",
         "x-cli-aliases": ["ls"]

--- a/example/example-show-hidden.json
+++ b/example/example-show-hidden.json
@@ -17,7 +17,8 @@
       "feature-flags": {
         "aliases": ["flags", "featureflags"]
       }
-    }
+    },
+    "x-cli-description": "The LaunchDarkly CLI lets you do all the things the API does but from the CL"
   },
   "servers": [
     {

--- a/example/example-show-hidden.json
+++ b/example/example-show-hidden.json
@@ -72,7 +72,8 @@
         "tags": ["Foo"],
         "summary": "Get all foos",
         "description": "Get all foos",
-        "operationId": "getAllFoos"
+        "operationId": "getAllFoos",
+        "x-cli-ignore": true
       },
       "post": {
         "responses": {
@@ -107,7 +108,8 @@
             }
           },
           "required": true
-        }
+        },
+        "x-cli-ignore": true
       },
       "put": {
         "responses": {
@@ -132,7 +134,8 @@
           }
         },
         "summary": "Put foo",
-        "description": "Overwrite a foo"
+        "description": "Overwrite a foo",
+        "x-cli-ignore": true
       }
     },
     "/api/v2/foo-spaces": {
@@ -161,7 +164,8 @@
         "tags": ["Foo With Spaces"],
         "summary": "Get foos with spaces",
         "description": "Get foos with spaces",
-        "operationId": "getFoosWithSpaces"
+        "operationId": "getFoosWithSpaces",
+        "x-cli-ignore": true
       }
     },
     "/api/v2/foo/{id}": {
@@ -211,7 +215,8 @@
           },
           "required": true
         },
-        "operationId": "patchFoo"
+        "operationId": "patchFoo",
+        "x-cli-ignore": true
       }
     },
     "/api/v2/foo/{id}/inner": {
@@ -238,7 +243,8 @@
           }
         },
         "summary": "Get inner foos",
-        "description": "Get Inner Foos"
+        "description": "Get Inner Foos",
+        "x-cli-ignore": true
       }
     },
     "/api/v2/showHidden": {
@@ -256,7 +262,8 @@
           }
         },
         "summary": "Hidden Route",
-        "operationId": "getHiddenRoutes"
+        "operationId": "getHiddenRoutes",
+        "x-cli-ignore": true
       }
     },
     "/api/v2/vfoo": {
@@ -284,7 +291,8 @@
         },
         "tags": ["Vfoo"],
         "summary": "Get Foo as var",
-        "description": "get a foo var"
+        "description": "get a foo var",
+        "x-cli-ignore": true
       }
     }
   },

--- a/example/example-show-hidden.json
+++ b/example/example-show-hidden.json
@@ -15,7 +15,8 @@
     "version": "2.0",
     "x-cli-groups": {
       "feature-flags": {
-        "aliases": ["flags", "featureflags"]
+        "aliases": ["flags", "featureflags"],
+        "description": "Do stuff with feature flags"
       }
     },
     "x-cli-description": "The LaunchDarkly CLI lets you do all the things the API does but from the CL"
@@ -43,9 +44,9 @@
         "summary": "Get all birds",
         "description": "DefaultDescription",
         "operationId": "getBirds",
-        "x-cli-description": "DefaultDescription",
         "x-cli-group": "birds",
         "x-cli-name": "list",
+        "x-cli-description": "DefaultDescription",
         "x-cli-aliases": ["ls"]
       }
     },

--- a/example/example-show-hidden.json
+++ b/example/example-show-hidden.json
@@ -12,7 +12,12 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "2.0"
+    "version": "2.0",
+    "x-cli-groups": {
+      "feature-flags": {
+        "aliases": ["flags", "featureflags"]
+      }
+    }
   },
   "servers": [
     {
@@ -35,7 +40,10 @@
           }
         },
         "summary": "Get all birds",
-        "operationId": "getBirds"
+        "operationId": "getBirds",
+        "x-cli-group": "birds",
+        "x-cli-name": "list",
+        "x-cli-aliases": ["ls"]
       }
     },
     "/api/v2/foo": {
@@ -61,9 +69,7 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": [
-          "Foo"
-        ],
+        "tags": ["Foo"],
         "summary": "Get all foos",
         "description": "Get all foos",
         "operationId": "getAllFoos"
@@ -152,9 +158,7 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": [
-          "Foo With Spaces"
-        ],
+        "tags": ["Foo With Spaces"],
         "summary": "Get foos with spaces",
         "description": "Get foos with spaces",
         "operationId": "getFoosWithSpaces"
@@ -278,9 +282,7 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": [
-          "Vfoo"
-        ],
+        "tags": ["Vfoo"],
         "summary": "Get Foo as var",
         "description": "get a foo var"
       }
@@ -290,9 +292,7 @@
     "schemas": {
       "Animal": {
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -301,9 +301,7 @@
       },
       "Birb": {
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -343,10 +341,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "example1",
-                "example2"
-              ]
+              "enum": ["example1", "example2"]
             }
           }
         }
@@ -442,10 +437,7 @@
           },
           "myEnum": {
             "type": "string",
-            "enum": [
-              "value1",
-              "value2"
-            ]
+            "enum": ["value1", "value2"]
           },
           "changeReturn": {
             "$ref": "#/components/schemas/Instruction"
@@ -487,10 +479,7 @@
   },
   "security": [
     {
-      "ApiKey": [
-        "read",
-        "write"
-      ]
+      "ApiKey": ["read", "write"]
     }
   ],
   "tags": [

--- a/example/example.json
+++ b/example/example.json
@@ -17,7 +17,9 @@
       "feature-flags": {
         "aliases": ["flags", "featureflags"]
       }
-    }
+    
+    },
+    "x-cli-description": "foo"
   },
   "servers": [
     {

--- a/example/example.json
+++ b/example/example.json
@@ -17,9 +17,8 @@
       "feature-flags": {
         "aliases": ["flags", "featureflags"]
       }
-    
     },
-    "x-cli-description": "foo"
+    "x-cli-description": "The LaunchDarkly CLI lets you do all the things the API does but from the CL"
   },
   "servers": [
     {

--- a/example/example.json
+++ b/example/example.json
@@ -41,7 +41,9 @@
           }
         },
         "summary": "Get all birds",
+        "description": "DefaultDescription",
         "operationId": "getBirds",
+        "x-cli-description": "DefaultDescription",
         "x-cli-group": "birds",
         "x-cli-name": "list",
         "x-cli-aliases": ["ls"]

--- a/example/example.json
+++ b/example/example.json
@@ -72,7 +72,8 @@
         "tags": ["Foo"],
         "summary": "Get all foos",
         "description": "Get all foos",
-        "operationId": "getAllFoos"
+        "operationId": "getAllFoos",
+        "x-cli-ignore": true
       },
       "post": {
         "responses": {
@@ -107,7 +108,8 @@
             }
           },
           "required": true
-        }
+        },
+        "x-cli-ignore": true
       },
       "put": {
         "responses": {
@@ -132,7 +134,8 @@
           }
         },
         "summary": "Put foo",
-        "description": "Overwrite a foo"
+        "description": "Overwrite a foo",
+        "x-cli-ignore": true
       }
     },
     "/api/v2/foo-spaces": {
@@ -161,7 +164,8 @@
         "tags": ["Foo With Spaces"],
         "summary": "Get foos with spaces",
         "description": "Get foos with spaces",
-        "operationId": "getFoosWithSpaces"
+        "operationId": "getFoosWithSpaces",
+        "x-cli-ignore": true
       }
     },
     "/api/v2/foo/{id}": {
@@ -211,7 +215,8 @@
           },
           "required": true
         },
-        "operationId": "patchFoo"
+        "operationId": "patchFoo",
+        "x-cli-ignore": true
       }
     },
     "/api/v2/foo/{id}/inner": {
@@ -238,7 +243,8 @@
           }
         },
         "summary": "Get inner foos",
-        "description": "Get Inner Foos"
+        "description": "Get Inner Foos",
+        "x-cli-ignore": true
       }
     },
     "/api/v2/vfoo": {
@@ -266,7 +272,8 @@
         },
         "tags": ["Vfoo"],
         "summary": "Get Foo as var",
-        "description": "get a foo var"
+        "description": "get a foo var",
+        "x-cli-ignore": true
       }
     }
   },

--- a/example/example.json
+++ b/example/example.json
@@ -15,7 +15,8 @@
     "version": "2.0",
     "x-cli-groups": {
       "feature-flags": {
-        "aliases": ["flags", "featureflags"]
+        "aliases": ["flags", "featureflags"],
+        "description": "Do stuff with feature flags"
       }
     },
     "x-cli-description": "The LaunchDarkly CLI lets you do all the things the API does but from the CL"
@@ -43,9 +44,9 @@
         "summary": "Get all birds",
         "description": "DefaultDescription",
         "operationId": "getBirds",
-        "x-cli-description": "DefaultDescription",
         "x-cli-group": "birds",
         "x-cli-name": "list",
+        "x-cli-description": "DefaultDescription",
         "x-cli-aliases": ["ls"]
       }
     },

--- a/example/example.json
+++ b/example/example.json
@@ -12,7 +12,12 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "2.0"
+    "version": "2.0",
+    "x-cli-groups": {
+      "feature-flags": {
+        "aliases": ["flags", "featureflags"]
+      }
+    }
   },
   "servers": [
     {
@@ -35,7 +40,10 @@
           }
         },
         "summary": "Get all birds",
-        "operationId": "getBirds"
+        "operationId": "getBirds",
+        "x-cli-group": "birds",
+        "x-cli-name": "list",
+        "x-cli-aliases": ["ls"]
       }
     },
     "/api/v2/foo": {
@@ -61,9 +69,7 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": [
-          "Foo"
-        ],
+        "tags": ["Foo"],
         "summary": "Get all foos",
         "description": "Get all foos",
         "operationId": "getAllFoos"
@@ -152,9 +158,7 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": [
-          "Foo With Spaces"
-        ],
+        "tags": ["Foo With Spaces"],
         "summary": "Get foos with spaces",
         "description": "Get foos with spaces",
         "operationId": "getFoosWithSpaces"
@@ -260,9 +264,7 @@
             "description": "Invalid resource identifier"
           }
         },
-        "tags": [
-          "Vfoo"
-        ],
+        "tags": ["Vfoo"],
         "summary": "Get Foo as var",
         "description": "get a foo var"
       }
@@ -272,9 +274,7 @@
     "schemas": {
       "Animal": {
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -283,9 +283,7 @@
       },
       "Birb": {
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -325,10 +323,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "example1",
-                "example2"
-              ]
+              "enum": ["example1", "example2"]
             }
           }
         }
@@ -424,10 +419,7 @@
           },
           "myEnum": {
             "type": "string",
-            "enum": [
-              "value1",
-              "value2"
-            ]
+            "enum": ["value1", "value2"]
           },
           "changeReturn": {
             "$ref": "#/components/schemas/Instruction"
@@ -469,10 +461,7 @@
   },
   "security": [
     {
-      "ApiKey": [
-        "read",
-        "write"
-      ]
+      "ApiKey": ["read", "write"]
     }
   ],
   "tags": [

--- a/example/foo.go
+++ b/example/foo.go
@@ -147,6 +147,9 @@ func getFoosSpacesInTag() {
 // @OperationId getBirds
 // @Route /api/v2/birds [get]
 // @Success 200 object Bird "Success"
+// @CliGroup birds
+// @CliName list
+// @CliAlias ls
 func getBirds() {
 
 }

--- a/example/foo.go
+++ b/example/foo.go
@@ -145,6 +145,7 @@ func getFoosSpacesInTag() {
 
 // @Title Get all birds
 // @OperationId getBirds
+// @Description DefaultDescription
 // @Route /api/v2/birds [get]
 // @Success 200 object Bird "Success"
 // @CliGroup birds

--- a/example/foo.go
+++ b/example/foo.go
@@ -149,7 +149,7 @@ func getFoosSpacesInTag() {
 // @Success 200 object Bird "Success"
 // @CliGroup birds
 // @CliName list
-// @CliAlias ls
+// @CliOperationAliases ls
 func getBirds() {
 
 }

--- a/example/main.go
+++ b/example/main.go
@@ -18,7 +18,6 @@ package main
 // @Tags "Foo With Spaces"
 // @CliGroups feature-flags aliases:flags,featureflags
 // @CliDescription The LaunchDarkly CLI lets you do all the things the API does but from the CL
-
 func main() {
 
 }

--- a/example/main.go
+++ b/example/main.go
@@ -17,7 +17,7 @@ package main
 // @Tags "Vfoo"
 // @Tags "Foo With Spaces"
 // @CliGroups feature-flags aliases:flags,featureflags
-// @CliDescription foo
+// @CliDescription The LaunchDarkly CLI lets you do all the things the API does but from the CL
 
 func main() {
 

--- a/example/main.go
+++ b/example/main.go
@@ -16,7 +16,7 @@ package main
 // @Tags "Bar" "Baz"
 // @Tags "Vfoo"
 // @Tags "Foo With Spaces"
-// @CliGroups feature-flags aliases:flags,featureflags
+// @CliGroups feature-flags aliases:flags,featureflags description:"Do stuff with feature flags"
 // @CliDescription The LaunchDarkly CLI lets you do all the things the API does but from the CL
 func main() {
 

--- a/example/main.go
+++ b/example/main.go
@@ -16,6 +16,7 @@ package main
 // @Tags "Bar" "Baz"
 // @Tags "Vfoo"
 // @Tags "Foo With Spaces"
+// @CliGroups feature-flags aliases:flags,featureflags
 
 func main() {
 

--- a/example/main.go
+++ b/example/main.go
@@ -17,6 +17,7 @@ package main
 // @Tags "Vfoo"
 // @Tags "Foo With Spaces"
 // @CliGroups feature-flags aliases:flags,featureflags
+// @CliDescription foo
 
 func main() {
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/goas
 
-go 1.15
+go 1.17
 
 require (
 	github.com/iancoleman/orderedmap v0.1.0
@@ -8,4 +8,14 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.5
 	golang.org/x/mod v0.4.0
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/oas.go
+++ b/oas.go
@@ -48,8 +48,9 @@ type InfoObject struct {
 }
 
 type CliConfigObject struct {
-	Aliases []string `json:"aliases,omitempty"`
-	Parent  string   `json:"parent,omitempty"`
+	Aliases     []string `json:"aliases,omitempty"`
+	Parent      string   `json:"parent,omitempty"`
+	Description string   `json:"description,omitempty"`
 }
 
 // Wrapper for a string that may be of the form `$ref:foo`

--- a/oas.go
+++ b/oas.go
@@ -49,6 +49,7 @@ type InfoObject struct {
 
 type CliConfigObject struct {
 	Aliases []string `json:"aliases,omitempty"`
+	Parent  string   `json:"parent,omitempty"`
 }
 
 // Wrapper for a string that may be of the form `$ref:foo`

--- a/oas.go
+++ b/oas.go
@@ -102,17 +102,17 @@ type PathItemObject struct {
 }
 
 type OperationObject struct {
-	Responses   ResponsesObject    `json:"responses"` // Required
-	Tags        []string           `json:"tags,omitempty"`
-	Summary     string             `json:"summary,omitempty"`
-	Description string             `json:"description,omitempty"`
-	Parameters  []ParameterObject  `json:"parameters,omitempty"`
-	RequestBody *RequestBodyObject `json:"requestBody,omitempty"`
-	OperationID string             `json:"operationId,omitempty"`
-	CliIgnore   bool               `json:"x-cli-ignore,omitempty"`
-	CliGroup    string             `json:"x-cli-group,omitempty"`
-	CliName     string             `json:"x-cli-name,omitempty"`
-	CliAlias    []string           `json:"x-cli-aliases,omitempty"`
+	Responses           ResponsesObject    `json:"responses"` // Required
+	Tags                []string           `json:"tags,omitempty"`
+	Summary             string             `json:"summary,omitempty"`
+	Description         string             `json:"description,omitempty"`
+	Parameters          []ParameterObject  `json:"parameters,omitempty"`
+	RequestBody         *RequestBodyObject `json:"requestBody,omitempty"`
+	OperationID         string             `json:"operationId,omitempty"`
+	CliIgnore           bool               `json:"x-cli-ignore,omitempty"`
+	CliGroup            string             `json:"x-cli-group,omitempty"`
+	CliName             string             `json:"x-cli-name,omitempty"`
+	CliOperationAliases []string           `json:"x-cli-aliases,omitempty"`
 
 	// Tags
 	// ExternalDocs

--- a/oas.go
+++ b/oas.go
@@ -37,12 +37,17 @@ type ServerObject struct {
 }
 
 type InfoObject struct {
-	Title          string          `json:"title"`
-	Description    *ReffableString `json:"description,omitempty"`
-	TermsOfService string          `json:"termsOfService,omitempty"`
-	Contact        *ContactObject  `json:"contact,omitempty"`
-	License        *LicenseObject  `json:"license,omitempty"`
-	Version        string          `json:"version"`
+	Title          string                     `json:"title"`
+	Description    *ReffableString            `json:"description,omitempty"`
+	TermsOfService string                     `json:"termsOfService,omitempty"`
+	Contact        *ContactObject             `json:"contact,omitempty"`
+	License        *LicenseObject             `json:"license,omitempty"`
+	Version        string                     `json:"version"`
+	CliGroups      map[string]CliConfigObject `json:"x-cli-groups,omitempty"`
+}
+
+type CliConfigObject struct {
+	Aliases []string `json:"aliases,omitempty"`
 }
 
 // Wrapper for a string that may be of the form `$ref:foo`
@@ -97,14 +102,18 @@ type PathItemObject struct {
 }
 
 type OperationObject struct {
-	Responses ResponsesObject `json:"responses"` // Required
-
+	Responses   ResponsesObject    `json:"responses"` // Required
 	Tags        []string           `json:"tags,omitempty"`
 	Summary     string             `json:"summary,omitempty"`
 	Description string             `json:"description,omitempty"`
 	Parameters  []ParameterObject  `json:"parameters,omitempty"`
 	RequestBody *RequestBodyObject `json:"requestBody,omitempty"`
 	OperationID string             `json:"operationId,omitempty"`
+	CliIgnore   bool               `json:"x-cli-ignore,omitempty"`
+	CliGroup    string             `json:"x-cli-group,omitempty"`
+	CliName     string             `json:"x-cli-name,omitempty"`
+	CliAlias    []string           `json:"x-cli-aliases,omitempty"`
+
 	// Tags
 	// ExternalDocs
 	// OperationID

--- a/oas.go
+++ b/oas.go
@@ -44,6 +44,7 @@ type InfoObject struct {
 	License        *LicenseObject             `json:"license,omitempty"`
 	Version        string                     `json:"version"`
 	CliGroups      map[string]CliConfigObject `json:"x-cli-groups,omitempty"`
+	CliDescription string                     `json:"x-cli-description,omitempty"`
 }
 
 type CliConfigObject struct {
@@ -102,17 +103,18 @@ type PathItemObject struct {
 }
 
 type OperationObject struct {
-	Responses           ResponsesObject    `json:"responses"` // Required
-	Tags                []string           `json:"tags,omitempty"`
-	Summary             string             `json:"summary,omitempty"`
-	Description         string             `json:"description,omitempty"`
-	Parameters          []ParameterObject  `json:"parameters,omitempty"`
-	RequestBody         *RequestBodyObject `json:"requestBody,omitempty"`
-	OperationID         string             `json:"operationId,omitempty"`
-	CliIgnore           bool               `json:"x-cli-ignore,omitempty"`
-	CliGroup            string             `json:"x-cli-group,omitempty"`
-	CliName             string             `json:"x-cli-name,omitempty"`
-	CliOperationAliases []string           `json:"x-cli-aliases,omitempty"`
+	Responses               ResponsesObject    `json:"responses"` // Required
+	Tags                    []string           `json:"tags,omitempty"`
+	Summary                 string             `json:"summary,omitempty"`
+	Description             string             `json:"description,omitempty"`
+	Parameters              []ParameterObject  `json:"parameters,omitempty"`
+	RequestBody             *RequestBodyObject `json:"requestBody,omitempty"`
+	OperationID             string             `json:"operationId,omitempty"`
+	CliGroup                string             `json:"x-cli-group,omitempty"`
+	CliName                 string             `json:"x-cli-name,omitempty"`
+	CliOperationDescription string             `json:"x-cli-description,omitempty"`
+	CliIgnore               bool               `json:"x-cli-ignore,omitempty"`
+	CliOperationAliases     []string           `json:"x-cli-aliases,omitempty"`
 
 	// Tags
 	// ExternalDocs

--- a/parser.go
+++ b/parser.go
@@ -501,6 +501,8 @@ func (p *parser) parseEntryPoint() error {
 						return err
 					}
 					p.OpenAPI.Info.CliGroups[group] = cfg
+				case "@clidescription":
+					p.OpenAPI.Info.CliDescription = value
 				case "@packagealias":
 					originalName, newName, err := parsePackageAliases(comment)
 
@@ -980,13 +982,15 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			}
 		case "@route", "@router":
 			err = p.parseRouteComment(operation, comment)
-		case "@cligroup", "@clioperationaliases", "@cliname":
+		case "@cligroup", "@clioperationaliases", "@cliname", "@clioperationdescription":
 			operation.CliIgnore = false
 			switch strings.ToLower(attribute) {
 			case "@cligroup":
 				operation.CliGroup = value
 			case "@cliname":
 				operation.CliName = value
+			case "@clioperationdescription":
+				operation.CliOperationDescription = value
 			case "@clioperationaliases":
 				operation.CliOperationAliases = strings.Split(value, ",")
 			}

--- a/parser.go
+++ b/parser.go
@@ -999,6 +999,11 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			return err
 		}
 	}
+
+	if operation.CliOperationDescription == "" && operation.CliIgnore == false {
+		operation.CliOperationDescription = operation.Description
+	}
+
 	return nil
 }
 

--- a/parser.go
+++ b/parser.go
@@ -935,6 +935,8 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 		tagList = append(tagList, tag.Name)
 	}
 
+	operation.CliIgnore = true
+
 	for _, astComment := range astComments {
 		comment := strings.TrimSpace(strings.TrimLeft(astComment.Text, "/"))
 		if len(comment) == 0 {
@@ -967,17 +969,19 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			}
 		case "@route", "@router":
 			err = p.parseRouteComment(operation, comment)
-		case "@cligroup":
-			operation.CliGroup = value
-		case "@cliignore":
-			operation.CliIgnore = true
-		case "@cliname":
-			operation.CliName = value
-		case "@clioperationaliases":
-			operation.CliOperationAliases = strings.Split(value, ",")
-		}
-		if err != nil {
-			return err
+		case "@cligroup", "@clioperationaliases", "@cliname":
+			operation.CliIgnore = false
+			switch strings.ToLower(attribute) {
+			case "@cligroup":
+				operation.CliGroup = value
+			case "@cliname":
+				operation.CliName = value
+			case "@clioperationaliases":
+				operation.CliOperationAliases = strings.Split(value, ",")
+			}
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/parser.go
+++ b/parser.go
@@ -548,7 +548,7 @@ func parseCliGroups(value string) (string, CliConfigObject, error) {
 
 	matches := r.FindStringSubmatch(value)
 	if len(matches) == 0 {
-		return "", CliConfigObject{}, fmt.Errorf("Expected: @CliGroups <command> (optional) aliases:<alias1,alias2,etc> Received: %s", "@CliGroups "+value)
+		return "", CliConfigObject{}, fmt.Errorf("Expected: @CliGroups <group> (optional) aliases:<alias1,alias2,etc> (optional) description:\"Descriptive words\" Received: %s", "@CliGroups "+value)
 	}
 
 	names := r.SubexpNames()

--- a/parser.go
+++ b/parser.go
@@ -379,8 +379,6 @@ func (p *parser) parseEntryPoint() error {
 				}
 				// p.debug(attribute, value)
 				switch attribute {
-				case "@cligroups":
-					p.parseCliGroups(value)
 				case "@version":
 					p.OpenAPI.Info.Version = value
 				case "@title":
@@ -497,6 +495,8 @@ func (p *parser) parseEntryPoint() error {
 					}
 
 					p.OpenAPI.Tags = append(p.OpenAPI.Tags, *t)
+				case "@cligroups":
+					p.parseCliGroups(value)
 				case "@packagealias":
 					originalName, newName, err := parsePackageAliases(comment)
 
@@ -944,14 +944,6 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 		attribute := strings.Fields(comment)[0]
 		value := strings.TrimSpace(comment[len(attribute):])
 		switch strings.ToLower(attribute) {
-		case "@cligroup":
-			operation.CliGroup = value
-		case "@cliignore":
-			operation.CliIgnore = true
-		case "@cliname":
-			operation.CliName = value
-		case "@clioperationaliases":
-			operation.CliOperationAliases = strings.Split(value, ",")
 		case "@title":
 			operation.Summary = value
 		case "@description":
@@ -975,6 +967,14 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			}
 		case "@route", "@router":
 			err = p.parseRouteComment(operation, comment)
+		case "@cligroup":
+			operation.CliGroup = value
+		case "@cliignore":
+			operation.CliIgnore = true
+		case "@cliname":
+			operation.CliName = value
+		case "@clioperationaliases":
+			operation.CliOperationAliases = strings.Split(value, ",")
 		}
 		if err != nil {
 			return err

--- a/parser.go
+++ b/parser.go
@@ -990,9 +990,9 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			case "@clioperationaliases":
 				operation.CliOperationAliases = strings.Split(value, ",")
 			}
-			if err != nil {
-				return err
-			}
+		}
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/parser.go
+++ b/parser.go
@@ -950,8 +950,8 @@ func (p *parser) parseOperation(pkgPath, pkgName string, astComments []*ast.Comm
 			operation.CliIgnore = true
 		case "@cliname":
 			operation.CliName = value
-		case "@clialias":
-			operation.CliAlias = strings.Split(value, ",")
+		case "@clioperationaliases":
+			operation.CliOperationAliases = strings.Split(value, ",")
 		case "@title":
 			operation.Summary = value
 		case "@description":

--- a/parser_test.go
+++ b/parser_test.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/token"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -25,9 +24,6 @@ func TestExample(t *testing.T) {
 	bts, err := json.MarshalIndent(p.OpenAPI, "", "    ")
 	require.NoError(t, err)
 
-	// jsonString, _ := json.Marshal(bts)
-	// ioutil.WriteFile("big_marhsall.json", bts, os.ModePerm)
-
 	expected, _ := ioutil.ReadFile("./example/example.json")
 	require.JSONEq(t, string(expected), string(bts))
 }
@@ -41,7 +37,6 @@ func TestShowHiddenExample(t *testing.T) {
 
 	bts, err := json.MarshalIndent(p.OpenAPI, "", "    ")
 	require.NoError(t, err)
-	ioutil.WriteFile("big_marhsall.json", bts, os.ModePerm)
 
 	expected, _ := ioutil.ReadFile("./example/example-show-hidden.json")
 	require.JSONEq(t, string(expected), string(bts))

--- a/parser_test.go
+++ b/parser_test.go
@@ -132,15 +132,18 @@ func Test_parseCliGroups(t *testing.T) {
 		require.Equal(t, CliConfigObject{}, cfg)
 	})
 
-	t.Run("missing aliases label", func(t *testing.T) {
-		_, _, err := parseCliGroups("feature-flags flags,featureflags")
-		require.Error(t, err)
-		require.Equal(t, "Expected: @CliGroups <command> (optional) aliases:<alias1,alias2,etc> Received: @CliGroups feature-flags flags,featureflags. Did you forget the \"aliases\" label?", err.Error())
+	t.Run("all attributes", func(t *testing.T) {
+		group, cfg, err := parseCliGroups(`targets aliases:user-targets parent:user-settings description:"Do stuff with user targets"`)
+		require.NoError(t, err)
+		require.Equal(t, "targets", group) // subgroup
+		require.Equal(t, CliConfigObject{Aliases: []string{"user-targets"}, Parent: "user-settings", Description: "Do stuff with user targets"}, cfg)
 	})
 
-	t.Run("too many spaces", func(t *testing.T) {
-		_, _, err := parseCliGroups("projects aliases: proj,project")
-		require.Error(t, err)
+	t.Run("different attribute order", func(t *testing.T) {
+		group, cfg, err := parseCliGroups(`projects description:"Do stuff with projects" aliases:proj,project`)
+		require.NoError(t, err)
+		require.Equal(t, "projects", group)
+		require.Equal(t, CliConfigObject{Aliases: []string{"proj", "project"}, Description: "Do stuff with projects"}, cfg)
 	})
 
 	t.Run("empty value", func(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/token"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -24,6 +25,9 @@ func TestExample(t *testing.T) {
 	bts, err := json.MarshalIndent(p.OpenAPI, "", "    ")
 	require.NoError(t, err)
 
+	// jsonString, _ := json.Marshal(bts)
+	// ioutil.WriteFile("big_marhsall.json", bts, os.ModePerm)
+
 	expected, _ := ioutil.ReadFile("./example/example.json")
 	require.JSONEq(t, string(expected), string(bts))
 }
@@ -37,6 +41,7 @@ func TestShowHiddenExample(t *testing.T) {
 
 	bts, err := json.MarshalIndent(p.OpenAPI, "", "    ")
 	require.NoError(t, err)
+	ioutil.WriteFile("big_marhsall.json", bts, os.ModePerm)
 
 	expected, _ := ioutil.ReadFile("./example/example-show-hidden.json")
 	require.JSONEq(t, string(expected), string(bts))

--- a/parser_test.go
+++ b/parser_test.go
@@ -116,6 +116,39 @@ func Test_parseTags(t *testing.T) {
 	})
 }
 
+func Test_parseCliGroups(t *testing.T) {
+	t.Run("group and aliases", func(t *testing.T) {
+		// we only expect the value here, not the whole comment (omitting "@CliGroups")
+		group, cfg, err := parseCliGroups("feature-flags aliases:flags,featureflags")
+		require.NoError(t, err)
+		require.Equal(t, "feature-flags", group)
+		require.Equal(t, CliConfigObject{Aliases: []string{"flags", "featureflags"}}, cfg)
+	})
+
+	t.Run("group only", func(t *testing.T) {
+		group, cfg, err := parseCliGroups("feature-flags")
+		require.NoError(t, err)
+		require.Equal(t, "feature-flags", group)
+		require.Equal(t, CliConfigObject{}, cfg)
+	})
+
+	t.Run("missing aliases label", func(t *testing.T) {
+		_, _, err := parseCliGroups("feature-flags flags,featureflags")
+		require.Error(t, err)
+		require.Equal(t, "Expected: @CliGroups <command> (optional) aliases:<alias1,alias2,etc> Received: @CliGroups feature-flags flags,featureflags. Did you forget the \"aliases\" label?", err.Error())
+	})
+
+	t.Run("too many spaces", func(t *testing.T) {
+		_, _, err := parseCliGroups("projects aliases: proj,project")
+		require.Error(t, err)
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		_, _, err := parseCliGroups("")
+		require.Error(t, err)
+	})
+}
+
 func Test_handleCompoundType(t *testing.T) {
 	t.Run("oneOf", func(t *testing.T) {
 		p, err := setupParser()


### PR DESCRIPTION
Adds a `CliGroups` config object containing `Aliases`, `Parent`, and `Description` to the `InfoObject` and `CliIgnore`, `CliOperationAliases` and `CliGroups` to the `OperationObject` for CLI extension fields & updates parsing to handle them.

Tests also updated