### PR TITLE
Supporting case for having type aliases in structs

### DIFF
--- a/example/example-show-hidden.json
+++ b/example/example-show-hidden.json
@@ -299,14 +299,21 @@
           }
         }
       },
+      "AnimalAlias": {
+        "$ref": "#/components/schemas/Animal"
+      },
       "Birb": {
         "type": "object",
         "required": [
-          "name"
+          "name",
+          "animalAlias"
         ],
         "properties": {
           "name": {
             "type": "string"
+          },
+          "animalAlias": {
+            "$ref": "#/components/schemas/Animal"
           },
           "airspeedVelocity": {
             "type": "number"

--- a/example/example.json
+++ b/example/example.json
@@ -281,14 +281,21 @@
           }
         }
       },
+      "AnimalAlias": {
+        "$ref": "#/components/schemas/Animal"
+      },
       "Birb": {
         "type": "object",
         "required": [
-          "name"
+          "name",
+          "animalAlias"
         ],
         "properties": {
           "name": {
             "type": "string"
+          },
+          "animalAlias": {
+            "$ref": "#/components/schemas/Animal"
           },
           "airspeedVelocity": {
             "type": "number"

--- a/example/foo.go
+++ b/example/foo.go
@@ -61,8 +61,11 @@ type FooMergePatch struct {
 // @ApiSchemaName Birb
 type Bird struct {
 	Animal
+	AnimalAlias      `json:"animalAlias" required:"true"`
 	AirspeedVelocity float32 `json:"airspeedVelocity"`
 }
+
+type AnimalAlias Animal
 
 // TODO since Animal is not used directly and probably shouldn't be included in the output spec
 type Animal struct {


### PR DESCRIPTION
In cases when we have an embedded type alias, `astField.Names` is nil (https://pkg.go.dev/go/ast#Field). We have example of referencing type aliases which were unhandled. When we detect these, use the tags metadata to build the schema.   