### PR TITLE
(maint) Parse 'uuid.UUID' as string with format uuid

### DIFF
--- a/example/example-show-hidden.json
+++ b/example/example-show-hidden.json
@@ -398,6 +398,10 @@
             "type": "string",
             "format": "date-time"
           },
+          "uniqueId": {
+            "type": "string",
+            "format": "uuid"
+          },
           "endDate": {
             "$ref": "#/components/schemas/UnixMillis"
           },

--- a/example/example.json
+++ b/example/example.json
@@ -380,6 +380,10 @@
             "type": "string",
             "format": "date-time"
           },
+          "uniqueId": {
+            "type": "string",
+            "format": "uuid"
+          },
           "endDate": {
             "$ref": "#/components/schemas/UnixMillis"
           },

--- a/example/foo.go
+++ b/example/foo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/google/uuid"
 	"time"
 
 	"gopkg.in/mgo.v2/bson"
@@ -19,6 +20,7 @@ type FooResponse struct {
 	BsonID        BsonID                 `json:"bsonId"`
 	ID            string                 `json:"id"`
 	StartDate     time.Time              `json:"startDate"`
+	UniqueId      uuid.UUID              `json:"uniqueId"`
 	EndDate       UnixMillis             `json:"endDate"`
 	Count         int64                  `json:"count" example:"6"`
 	Msg           json.RawMessage        `json:"msg"`

--- a/parser.go
+++ b/parser.go
@@ -1371,6 +1371,10 @@ func (p *parser) parseSchemaObject(pkgPath, pkgName, typeName string, register b
 		schemaObject.Type = &stringType
 		schemaObject.Format = "date-time"
 		return &schemaObject, nil
+	} else if typeName == "uuid.UUID" {
+		schemaObject.Type = &stringType
+		schemaObject.Format = "uuid"
+		return &schemaObject, nil
 	} else if strings.HasPrefix(typeName, "interface{}") {
 		schemaObject.Type = nil
 		return &schemaObject, nil
@@ -1595,7 +1599,7 @@ func (p *parser) parseAstField(pkgPath, pkgName string, structSchema *SchemaObje
 
 	isSliceOrMap := strings.HasPrefix(typeAsString, "[]") || strings.HasPrefix(typeAsString, "map[]")
 	isInterface := strings.HasPrefix(typeAsString, "interface{}")
-	if isSliceOrMap || isInterface || typeAsString == "time.Time" {
+	if isSliceOrMap || isInterface || typeAsString == "time.Time" || typeAsString == "uuid.UUID" {
 		splitType := strings.Split(typeAsString, "]")
 		if len(splitType) > 1 && !isBasicGoType(splitType[1]) {
 			if _, ok := p.KnownIDSchema[splitType[1]]; ok {


### PR DESCRIPTION
There's an issue when building the Java client library where it interprets `UUID` as the Java type UUID, which then fails to import what the API thinks is an array. [Based on this StackOverflow thread](https://stackoverflow.com/questions/50204588/how-to-define-uuid-property-in-json-schema-and-open-api-oas) it sounds like we want the UUID type to be interpreted as a String with format `uuid`, which openapi will likely know how to build into the correct type for libraries. This updates the parser to detect that specific Go type and correctly type it in the API spec.